### PR TITLE
feat: Add MiniMax providers and update models for v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2025-12-24
+
+### Added
+- **MiniMax Provider Support**: Full integration for MiniMax AI with two provider options:
+  - `minimax_cn`: For China users (国内版) with endpoint at `api.minimaxi.com`
+  - `minimax_global`: For international users (国际版) with endpoint at `api.minimax.io`
+  - Support for `MiniMax-M2.1` model
+  - Extended timeout configuration (50 minutes) for large response handling
+  - Optimized network traffic settings for better performance
+- **Enhanced Anthropic Models**: Added latest Claude models:
+  - `claude-sonnet-4.5`: Enhanced Sonnet model with improved capabilities
+  - `claude-opus-4.5`: Enhanced Opus model with improved capabilities
+- **DeepSeek Reasoner Model**: Added `deepseek-reasoner` model for complex reasoning tasks
+- **ZhiPu AI GLM-4.7**: Added `glm-4.7` model support for both:
+  - `zhipu` provider (智谱清言 - mainland China)
+  - `zai` provider (Z.ai Global - international users)
+
+### Changed
+- **Provider Names**: Updated ZhiPu AI provider names to reflect GLM-4.7 support:
+  - `zhipu`: Now shows "GLM-4.5/4.6/4.7" in display name
+  - `zai`: Now shows "GLM-4.5/4.6/4.7" in display name
+- **Documentation**: Updated README files to include MiniMax providers
+
+### Fixed
+- **Provider Selection**: Added MiniMax providers to third-party API selection menu
+
 ## [2.2.0] - 2025-11-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An elegant interactive launcher for Claude Code with a beautiful Claude-style in
 - Strong password requirements and validation
 
 ### 🚀 **Third-party API Management**
-- Full support for multiple third-party API providers (OpenAI, Anthropic, DeepSeek, Kimi, GLM (ZhiPu AI), and more)
+- Full support for multiple third-party API providers (OpenAI, Anthropic, DeepSeek, Kimi, MiniMax, GLM (ZhiPu AI), and more)
 - Interactive API configuration with validation
 - API usage statistics and tracking
 - Secure configuration backup and restore
@@ -158,7 +158,7 @@ Claude Launcher 2.0 uses an advanced configuration system:
 
 Configure any third-party API provider through the interactive interface:
 
-- **Supported Providers**: OpenAI, Anthropic, DeepSeek, Kimi, GLM (ZhiPu AI), and custom APIs
+- **Supported Providers**: OpenAI, Anthropic, DeepSeek, Kimi, MiniMax (CN/Global), GLM (ZhiPu AI), and custom APIs
 - **Secure Storage**: All API tokens encrypted before storage
 - **Validation**: Real-time validation of URLs, tokens, and models
 - **Usage Tracking**: Monitor API usage statistics

--- a/docs/README-zh.md
+++ b/docs/README-zh.md
@@ -25,7 +25,7 @@
 - 强密码要求和验证
 
 ### 🚀 **第三方 API 管理**
-- 全面支持多个第三方 API 提供商（OpenAI、Anthropic、DeepSeek、Kimi、GLM/智谱AI 和自定义 API）
+- 全面支持多个第三方 API 提供商（OpenAI、Anthropic、DeepSeek、Kimi、MiniMax、GLM/智谱AI 和自定义 API）
 - 带验证的交互式 API 配置
 - API 使用统计和跟踪
 - 安全的配置备份和恢复
@@ -158,7 +158,7 @@ Claude Launcher 2.0 使用先进的配置系统：
 
 通过交互界面配置任何第三方 API 提供商：
 
-- **支持的提供商**：OpenAI、Anthropic、DeepSeek、Kimi、GLM/智谱AI 和自定义 API
+- **支持的提供商**：OpenAI、Anthropic、DeepSeek、Kimi、MiniMax（国内版/国际版）、GLM/智谱AI 和自定义 API
 - **安全存储**：所有 API 令牌在存储前加密
 - **验证**：URL、令牌和模型的实时验证
 - **使用跟踪**：监控 API 使用统计

--- a/lib/presets/providers.js
+++ b/lib/presets/providers.js
@@ -58,6 +58,38 @@ const providers = {
         },
         note: 'Requires extended timeout for large responses'
     },
+    minimax_cn: {
+        name: 'MiniMax CN (国内版)',
+        baseUrl: 'https://api.minimaxi.com/anthropic',
+        models: [
+            'MiniMax-M2.1'
+        ],
+        authTokenFormat: 'sk-...',
+        description: 'MiniMax AI - Anthropic-compatible API for China users',
+        requiresToken: true,
+        compatibility: 'anthropic-compatible',
+        envVars: {
+            API_TIMEOUT_MS: '3000000',
+            CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+        },
+        note: 'Requires extended timeout for large responses'
+    },
+    minimax_global: {
+        name: 'MiniMax Global (国际版)',
+        baseUrl: 'https://api.minimax.io/anthropic',
+        models: [
+            'MiniMax-M2.1'
+        ],
+        authTokenFormat: 'sk-...',
+        description: 'MiniMax AI - Anthropic-compatible API for international users',
+        requiresToken: true,
+        compatibility: 'anthropic-compatible',
+        envVars: {
+            API_TIMEOUT_MS: '3000000',
+            CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+        },
+        note: 'Requires extended timeout for large responses'
+    },
     deepseek: {
         name: 'DeepSeek (DeepSeek V3/V3.1)',
         baseUrl: 'https://api.deepseek.com/anthropic',

--- a/lib/presets/providers.js
+++ b/lib/presets/providers.js
@@ -12,8 +12,10 @@ const providers = {
             'claude-3-5-haiku-20241022',
             'claude-3.7-sonnet',
             'claude-sonnet-4',
+            'claude-sonnet-4.5',
             'claude-opus-4',
-            'claude-opus-4.1'
+            'claude-opus-4.1',
+            'claude-opus-4.5'
         ],
         authTokenFormat: 'sk-ant-api03-...',
         description: 'Official Anthropic API - Fully compatible',
@@ -60,7 +62,8 @@ const providers = {
         name: 'DeepSeek (DeepSeek V3/V3.1)',
         baseUrl: 'https://api.deepseek.com/anthropic',
         models: [
-            'deepseek-chat'
+            'deepseek-chat',
+            'deepseek-reasoner'
         ],
         authTokenFormat: 'sk-...',
         description: 'DeepSeek AI - Anthropic-compatible endpoint',
@@ -73,11 +76,12 @@ const providers = {
         note: 'Requires extended timeout for complex reasoning tasks'
     },
     zhipu: {
-        name: 'ZhiPu AI (GLM-4.5/4.6) - 智谱清言',
+        name: 'ZhiPu AI (GLM-4.5/4.6/4.7) - 智谱清言',
         baseUrl: 'https://open.bigmodel.cn/api/anthropic',
         models: [
             'glm-4.5',
-            'glm-4.6'
+            'glm-4.6',
+            'glm-4.7'
         ],
         authTokenFormat: 'sk-...',
         description: 'ZhiPu AI (智谱清言) - Anthropic-compatible API for mainland China',
@@ -90,11 +94,12 @@ const providers = {
         note: 'Requires extended timeout for large responses'
     },
     zai: {
-        name: 'Z.ai (GLM-4.5/4.6) - ZhiPu Global',
+        name: 'Z.ai (GLM-4.5/4.6/4.7) - ZhiPu Global',
         baseUrl: 'https://api.z.ai/api/anthropic',
         models: [
             'glm-4.5',
-            'glm-4.6'
+            'glm-4.6',
+            'glm-4.7'
         ],
         authTokenFormat: 'sk-...',
         description: 'Z.ai (ZhiPu AI Global) - Anthropic-compatible API for international users',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kikkimo/claude-launcher",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kikkimo/claude-launcher",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kikkimo/claude-launcher",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Interactive launcher for Claude Code with beautiful Claude-style interface",
   "main": "claude-launcher",
   "bin": {


### PR DESCRIPTION
## Summary
- Add MiniMax CN and MiniMax Global providers with MiniMax-M2.1 model support
- Add new Anthropic models (claude-sonnet-4.5, claude-opus-4.5)
- Add DeepSeek reasoner model (deepseek-reasoner)
- Add ZhiPu AI GLM-4.7 model support for both zhipu and zai providers
- Update documentation (README, CHANGELOG)

## Test plan
- [ ] Test MiniMax CN provider configuration
- [ ] Test MiniMax Global provider configuration
- [ ] Test new Anthropic models
- [ ] Test DeepSeek reasoner model
- [ ] Test ZhiPu AI GLM-4.7 model
- [ ] Verify provider selection menu shows all new providers
- [ ] Verify documentation updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明 v2.3.0

* **新功能**
  * 新增 MiniMax 提供商集成（国内版和国际版）及 MiniMax-M2.1 模型
  * 新增 Claude Sonnet 4.5、Claude Opus 4.5 模型支持
  * 新增 DeepSeek Reasoner 和 ZhiPu GLM-4.7 模型支持

* **改进**
  * 扩展超时时间至 50 分钟
  * 网络性能优化

* **Bug 修复**
  * 修复 MiniMax 提供商在 API 选择菜单中的显示

* **文档**
  * 更新文档覆盖新增提供商信息

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->