### PR TITLE
feat: update models and add auto mode support (v2.5.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,8 +70,8 @@ Thumbs.db
 # Keep template file
 !claude-launcher-template.env
 
-# Test files (allow our stdin fix tests)
-test/
+# Test files
+!test/
 *.spec.js
 /.serena
 /.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-03-31
+
+### Added
+- **Claude Auto Mode Support**: New menu item "Launch Claude Code (Enable Auto Mode)" using `--enable-auto-mode` flag
+  - Enables auto mode as a selectable permission mode (switch with Shift+Tab in session)
+  - Currently supports Team plan; Enterprise/API plans rolling out
+- **Dynamic Menu Hints**: Context-sensitive hints displayed below the main menu based on selected item
+  - Auto Mode item: Shows plan support info and Shift+Tab usage instruction
+  - Third-party API items: Shows active API provider/model or prompts to configure
+  - Hints auto-hide when selecting other menu items
+- **GLM-5.1 & GLM-5-Turbo Models**: Added latest ZhiPu AI models for both `zhipu` and `zai` providers
+  - New models: `glm-5.1` (latest), `glm-5-turbo`
+  - Removed deprecated: `glm-4.5`, `glm-4.6`
+  - All older models now suggest upgrade to `glm-5.1`
+- **Kimi K2.5 Model**: Added latest Moonshot AI model for `moonshot` provider
+  - New model: `kimi-k2.5` (latest, multimodal, 256K context)
+  - Removed deprecated: `kimi-k2-0711-preview`, `kimi-k2-0905-preview`, `kimi-k2-turbo-preview`
+  - All older models now suggest upgrade to `kimi-k2.5`
+- **MiniMax M2.7 & M2.5 Models**: Added latest MiniMax models for both `minimax_cn` and `minimax_global` providers
+  - New models: `MiniMax-M2.7` (latest), `MiniMax-M2.5`
+  - Older models now suggest upgrade to `MiniMax-M2.7`
+- **Automated Test Suite**: Added test infrastructure with `npm test` entry point
+  - Provider model configuration tests (28 tests)
+  - Menu hintCallback rendering tests including navigate() stub tests (8 tests)
+
+### Changed
+- **Menu Structure**: Main menu now has 9 items (was 8), with Auto Mode at position 3
+- **i18n**: All 11 locale files updated with 4 new translation keys for Auto Mode and hints
+
 ## [2.4.0] - 2026-02-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An elegant interactive launcher for Claude Code with a beautiful Claude-style in
 - Strong password requirements and validation
 
 ### 🚀 **Third-party API Management**
-- Full support for multiple third-party API providers (OpenAI, Anthropic, DeepSeek, Kimi, MiniMax, GLM/ZhiPu AI, and custom APIs)
+- Full support for multiple third-party API providers (Anthropic, DeepSeek, Kimi K2.5, MiniMax M2.7, GLM-5.1/ZhiPu AI, and custom APIs)
 - Interactive API configuration with validation
 - API usage statistics with success/failure tracking
 - Model upgrade notifications and auto-upgrade support
@@ -84,16 +84,17 @@ node claude-launcher
 
 1. **Launch Claude Code** - Standard Claude Code launch
 2. **Launch Claude Code (Skip Permissions)** - Launch with `--dangerously-skip-permissions`
-3. **Launch Claude Code with Third-party API** - Use configured third-party API
-4. **Launch Claude Code with Third-party API (Skip Permissions)** - Combine third-party API with permission skipping
-5. **Third-party API Management** - Full API lifecycle management:
+3. **Launch Claude Code (Enable Auto Mode)** - Launch with `--enable-auto-mode` for classifier-gated auto approvals (Team plan; Shift+Tab to switch)
+4. **Launch Claude Code with Third-party API** - Use configured third-party API
+5. **Launch Claude Code with Third-party API (Skip Permissions)** - Combine third-party API with permission skipping
+6. **Third-party API Management** - Full API lifecycle management:
    - Add, switch, and remove APIs
    - View usage statistics with success/failure rates
    - Model upgrade settings (auto/manual upgrade)
    - Import/export configurations
-6. **Language Settings** - Switch between 11 supported languages
-7. **Version Update Check** - Check for launcher updates
-8. **Exit** - Close the launcher
+7. **Language Settings** - Switch between 11 supported languages
+8. **Version Update Check** - Check for launcher updates
+9. **Exit** - Close the launcher
 
 ### Interactive Navigation
 
@@ -115,6 +116,7 @@ $ claude-launcher
 
   → Launch Claude Code
     Launch Claude Code (Skip Permissions)
+    Launch Claude Code (Enable Auto Mode)
     Launch Claude Code with Third-party API
     Launch Claude Code with Third-party API (Skip Permissions)
     Third-party API Management
@@ -171,7 +173,7 @@ Claude Launcher 2.0 uses an advanced configuration system:
 
 Configure any third-party API provider through the interactive interface:
 
-- **Supported Providers**: Anthropic, OpenAI, DeepSeek, Moonshot/Kimi, MiniMax (CN/Global), GLM/ZhiPu AI (GLM-4, GLM-5), and custom Anthropic-compatible APIs
+- **Supported Providers**: Anthropic, DeepSeek, Moonshot/Kimi (K2.5), MiniMax (CN/Global, M2.7), GLM/ZhiPu AI (GLM-5.1), and custom Anthropic-compatible APIs
 - **Secure Storage**: All API tokens encrypted before storage
 - **Validation**: Real-time validation of URLs, tokens, and models
 - **Usage Tracking**: Monitor API usage statistics with success/failure rates
@@ -210,6 +212,12 @@ With password protection enabled:
 git clone https://github.com/kikkimo/claude-launcher.git
 cd claude-launcher
 npm install
+```
+
+### Running Tests
+
+```bash
+npm test
 ```
 
 ### Testing Locally

--- a/claude-launcher
+++ b/claude-launcher
@@ -46,6 +46,7 @@ const {
 const {
     launchClaudeDefault,
     launchClaudeSkipPermissions,
+    launchClaudeAutoMode,
     launchClaudeWithApi
 } = require('./lib/launcher');
 const { getPasswordInput } = require('./lib/auth/password-input');
@@ -967,24 +968,28 @@ async function executeSelection(selectedIndex) {
             launchClaudeSkipPermissions();
             break;
 
-        case 2: // Launch Claude Code with 3rd-party API
+        case 2: // Launch Claude Code (Enable Auto Mode)
+            launchClaudeAutoMode();
+            break;
+
+        case 3: // Launch Claude Code with 3rd-party API
             await handleThirdPartyApiLaunch(false);
             break;
 
-        case 3: // Launch Claude Code with 3rd-party API (Skip Permissions)
+        case 4: // Launch Claude Code with 3rd-party API (Skip Permissions)
             await handleThirdPartyApiLaunch(true);
             break;
 
-        case 4: // 3rd-party API Management
+        case 5: // 3rd-party API Management
             return await showApiManagementMenu();
 
-        case 5: // Language Settings
+        case 6: // Language Settings
             return await showLanguageSettings();
 
-        case 6: // Version Update Check
+        case 7: // Version Update Check
             return await showVersionUpdateCheck();
 
-        case 7: // Exit
+        case 8: // Exit
             console.log('');
             console.log(colors.green + '👋 ' + await i18n.t('menu.main.exit') + '!' + colors.reset);
             process.exit(0);
@@ -1093,6 +1098,7 @@ async function showMenu() {
     menuOptions = [
         await i18n.t('menu.main.launch_default'),
         await i18n.t('menu.main.launch_skip'),
+        await i18n.t('menu.main.launch_auto_mode'),
         await i18n.t('menu.main.launch_api'),
         await i18n.t('menu.main.launch_api_skip'),
         await i18n.t('menu.main.api_management'),
@@ -1101,8 +1107,31 @@ async function showMenu() {
         await i18n.t('menu.main.exit')
     ];
 
+    // Pre-compute hint texts synchronously for menu callback
+    const hintAutoMode = i18n.tSync('hints.auto_mode_info');
+    const activeApi = apiManager.getActiveApi();
+    let hintApiInfo = null;
+    if (activeApi) {
+        const { getProvider } = require('./lib/presets/providers');
+        const providerConfig = getProvider(activeApi.provider);
+        const providerName = providerConfig ? providerConfig.name : (activeApi.provider || 'Custom');
+        hintApiInfo = i18n.tSync('hints.active_api_info', providerName, activeApi.model);
+    } else {
+        hintApiInfo = i18n.tSync('hints.no_active_api');
+    }
+
+    // Synchronous hint callback — must not use await
+    const hintCallback = (selectedIndex) => {
+        switch (selectedIndex) {
+            case 2: return hintAutoMode;
+            case 3: return hintApiInfo;
+            case 4: return hintApiInfo;
+            default: return null;
+        }
+    };
+
     globalMainMenu.setOptions(menuOptions);
-    const selection = await globalMainMenu.navigate(false, displayInfo || null); // Pass combined info to display between banner and nav
+    const selection = await globalMainMenu.navigate(false, displayInfo || null, hintCallback);
 
     if (selection === -1) {
         console.log('');

--- a/docs/README-zh.md
+++ b/docs/README-zh.md
@@ -25,7 +25,7 @@
 - 强密码要求和验证
 
 ### 🚀 **第三方 API 管理**
-- 全面支持多个第三方 API 提供商（Anthropic、OpenAI、DeepSeek、Moonshot/Kimi、MiniMax、GLM/智谱AI 和自定义 API）
+- 全面支持多个第三方 API 提供商（Anthropic、DeepSeek、Kimi K2.5、MiniMax M2.7、GLM-5.1/智谱AI 和自定义 API）
 - 带验证的交互式 API 配置
 - API 使用统计，支持成功/失败率追踪
 - 模型升级通知和自动升级支持
@@ -84,16 +84,17 @@ node claude-launcher
 
 1. **启动 Claude Code** - 标准 Claude Code 启动
 2. **启动 Claude Code（跳过权限）** - 使用 `--dangerously-skip-permissions` 启动
-3. **使用第三方 API 启动 Claude Code** - 使用配置的第三方 API
-4. **使用第三方 API 启动 Claude Code（跳过权限）** - 结合第三方 API 和跳过权限
-5. **第三方 API 管理** - 完整的 API 生命周期管理：
+3. **启动 Claude Code（启用自动模式）** - 使用 `--enable-auto-mode` 启动，支持分类器自动审批（Team 计划；启动后按 Shift+Tab 切换）
+4. **使用第三方 API 启动 Claude Code** - 使用配置的第三方 API
+5. **使用第三方 API 启动 Claude Code（跳过权限）** - 结合第三方 API 和跳过权限
+6. **第三方 API 管理** - 完整的 API 生命周期管理：
    - 添加、切换和删除 API
    - 查看使用统计（含成功/失败率）
    - 模型升级设置（自动/手动升级）
    - 导入/导出配置
-6. **语言设置** - 在11种支持的语言之间切换
-7. **版本更新检查** - 检查启动器更新
-8. **退出** - 关闭启动器
+7. **语言设置** - 在11种支持的语言之间切换
+8. **版本更新检查** - 检查启动器更新
+9. **退出** - 关闭启动器
 
 ### 交互式导航
 
@@ -115,6 +116,7 @@ $ claude-launcher
 
   → 启动 Claude Code
     启动 Claude Code（跳过权限）
+    启动 Claude Code（启用自动模式）
     使用第三方 API 启动 Claude Code
     使用第三方 API 启动 Claude Code（跳过权限）
     第三方 API 管理
@@ -171,7 +173,7 @@ Claude Launcher 2.0 使用先进的配置系统：
 
 通过交互界面配置任何第三方 API 提供商：
 
-- **支持的提供商**：Anthropic、OpenAI、DeepSeek、Moonshot/Kimi、MiniMax（国内版/国际版）、GLM/智谱AI（GLM-4、GLM-5）和自定义 Anthropic 兼容 API
+- **支持的提供商**：Anthropic、DeepSeek、Moonshot/Kimi（K2.5）、MiniMax（国内版/国际版，M2.7）、GLM/智谱AI（GLM-5.1）和自定义 Anthropic 兼容 API
 - **安全存储**：所有 API 令牌在存储前加密
 - **验证**：URL、令牌和模型的实时验证
 - **使用跟踪**：监控 API 使用统计，支持成功/失败率追踪
@@ -210,6 +212,12 @@ Claude Launcher 2.0 使用先进的配置系统：
 git clone https://github.com/kikkimo/claude-launcher.git
 cd claude-launcher
 npm install
+```
+
+### 运行测试
+
+```bash
+npm test
 ```
 
 ### 本地测试

--- a/docs/superpowers/plans/2026-03-31-update-models-and-auto-mode.md
+++ b/docs/superpowers/plans/2026-03-31-update-models-and-auto-mode.md
@@ -33,6 +33,7 @@
 | `lib/i18n/locales/ru.js` | Modify | Add 4 new i18n keys (Russian) |
 | `test/providers.test.js` | Create | Tests for updated provider configs |
 | `test/menu-hints.test.js` | Create | Tests for hintCallback rendering |
+| `package.json` | Modify | Wire `npm test` to run both test files |
 
 ---
 
@@ -723,6 +724,59 @@ test('displayMenu: backward compat — works without hintCallback', () => {
     assert.strictEqual(hintLines.length, 0);
 });
 
+// ─── navigate() stores and passes through hintCallback ───
+
+test('navigate: stores hintCallback on instance', () => {
+    const m = new Menu();
+    m.setOptions(['A', 'B']);
+    const cb = (idx) => idx === 0 ? 'hint' : null;
+    // We can't fully run navigate() (it blocks on stdin), but we can
+    // verify the storage path by calling displayMenu via navigate's
+    // internal contract. Simulate what navigate does before blocking:
+    m.versionInfo = 'v1';
+    m.hintCallback = cb;
+    // After navigate() stores these, arrow key redraws call:
+    //   this.displayMenu(true, this.versionInfo, this.hintCallback)
+    // Verify this path renders the hint:
+    m.selectedIndex = 0;
+    const logs = captureLog(() => m.displayMenu(true, m.versionInfo, m.hintCallback));
+    assert.ok(logs.some(l => l.includes('hint')));
+});
+
+test('navigate: arrow key redraw uses stored hintCallback (simulated)', () => {
+    const m = new Menu();
+    m.setOptions(['A', 'B', 'C']);
+    const cb = (idx) => {
+        if (idx === 1) return 'Hint for B';
+        return null;
+    };
+    // Simulate what navigate() stores
+    m.versionInfo = null;
+    m.hintCallback = cb;
+
+    // Simulate up arrow: selectedIndex moves to 1
+    m.selectedIndex = 1;
+    const logs1 = captureLog(() => m.displayMenu(true, m.versionInfo, m.hintCallback));
+    assert.ok(logs1.some(l => l.includes('Hint for B')), 'Should show hint after arrow to index 1');
+
+    // Simulate another arrow: selectedIndex moves to 2
+    m.selectedIndex = 2;
+    const logs2 = captureLog(() => m.displayMenu(true, m.versionInfo, m.hintCallback));
+    assert.ok(!logs2.some(l => l.includes('ℹ')), 'Should hide hint after arrow to index 2');
+});
+
+test('navigate: hintCallback defaults to null when not provided', () => {
+    const m = new Menu();
+    m.setOptions(['A']);
+    // Simulate navigate(false, 'info') without 3rd arg
+    m.versionInfo = 'info';
+    m.hintCallback = null; // default
+    m.selectedIndex = 0;
+    const logs = captureLog(() => m.displayMenu(true, m.versionInfo, m.hintCallback));
+    const hintLines = logs.filter(l => l.includes('ℹ'));
+    assert.strictEqual(hintLines.length, 0);
+});
+
 // ─── Summary ───
 
 console.log(`\n  ${passed} passed, ${failed} failed\n`);
@@ -934,11 +988,35 @@ New `hints` section:
     },
 ```
 
-- [ ] **Step 12: Verify — load all locales without errors**
+- [ ] **Step 12: Verify — check all 4 keys exist and resolve in every locale**
 
-Run: `node -e "const locales = ['en','zh','zh-TW','ja','ko','de','fr','es','it','pt','ru']; locales.forEach(l => { const m = require('./lib/i18n/locales/' + l); console.log(l + ': launch_auto_mode=' + (m.menu.main.launch_auto_mode ? 'OK' : 'MISSING') + ', hints=' + (m.hints ? 'OK' : 'MISSING')); });"`
+Run:
+```bash
+node -e "
+const locales = ['en','zh','zh-TW','ja','ko','de','fr','es','it','pt','ru'];
+const keys = [
+  ['menu.main.launch_auto_mode', m => m.menu.main.launch_auto_mode],
+  ['hints.auto_mode_info',       m => m.hints && m.hints.auto_mode_info],
+  ['hints.active_api_info',      m => m.hints && m.hints.active_api_info],
+  ['hints.no_active_api',        m => m.hints && m.hints.no_active_api]
+];
+let ok = true;
+locales.forEach(l => {
+  const m = require('./lib/i18n/locales/' + l);
+  keys.forEach(([name, getter]) => {
+    const val = getter(m);
+    if (!val || val === name) {
+      console.log('FAIL ' + l + ': ' + name + ' = ' + JSON.stringify(val));
+      ok = false;
+    }
+  });
+  if (ok) console.log(l + ': all 4 keys OK');
+});
+if (!ok) { console.log('FAILED'); process.exit(1); }
+"
+```
 
-Expected: all 11 lines show `launch_auto_mode=OK, hints=OK`.
+Expected: all 11 lines show `all 4 keys OK`. If any key is missing or returns itself as a string, the check fails.
 
 - [ ] **Step 13: Commit**
 
@@ -1160,7 +1238,41 @@ git commit -m "feat: add auto mode menu item, dynamic hints, and shift menu indi
 
 ---
 
-### Task 10: Manual smoke test
+### Task 10: Wire npm test to run both test files
+
+**Files:**
+- Modify: `package.json:11` (scripts.test)
+
+- [ ] **Step 1: Update package.json test script**
+
+In `package.json`, change line 11 from:
+
+```json
+    "test": "echo \"No tests specified\" && exit 0",
+```
+
+to:
+
+```json
+    "test": "node test/providers.test.js && node test/menu-hints.test.js",
+```
+
+- [ ] **Step 2: Verify — run npm test**
+
+Run: `npm test`
+
+Expected: Both test files execute and all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json
+git commit -m "chore: wire npm test to run provider and menu hint tests"
+```
+
+---
+
+### Task 11: Manual smoke test
 
 - [ ] **Step 1: Launch the app**
 

--- a/docs/superpowers/plans/2026-03-31-update-models-and-auto-mode.md
+++ b/docs/superpowers/plans/2026-03-31-update-models-and-auto-mode.md
@@ -1,0 +1,1194 @@
+# Update Models & Add Auto Mode — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update GLM/Kimi/MiniMax model presets to current versions, add a Claude Code "Enable Auto Mode" launcher menu item, and add dynamic context hints that appear below the main menu based on the selected item.
+
+**Architecture:** Pure incremental changes to existing files. Model presets are updated in `providers.js`. A new `launchClaudeAutoMode()` thin wrapper is added to `launcher.js`. The `Menu` class gains an optional synchronous `hintCallback` third parameter that renders context text below menu items. The main `claude-launcher` file wires the new menu item, hint callback, and shifted case indices. All 11 i18n locale files get 4 new keys.
+
+**Tech Stack:** Node.js (zero dependencies), custom CLI menu system, custom i18n with `{0}`/`{1}` positional placeholders via `MessageFormatter.format()`.
+
+**Spec:** `docs/superpowers/specs/2026-03-31-update-models-and-auto-mode-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `lib/presets/providers.js` | Modify | Update zhipu, zai, moonshot, minimax_cn, minimax_global model lists/names/aliases |
+| `lib/launcher.js` | Modify | Add `launchClaudeAutoMode()` function and export |
+| `lib/ui/menu.js` | Modify | Add `hintCallback` 3rd param to `displayMenu()` and `navigate()` |
+| `claude-launcher` | Modify | New menu item at index 2, hint callback, import change, case index shifts |
+| `lib/i18n/locales/en.js` | Modify | Add 4 new i18n keys (English — canonical) |
+| `lib/i18n/locales/zh.js` | Modify | Add 4 new i18n keys (Chinese Simplified) |
+| `lib/i18n/locales/zh-TW.js` | Modify | Add 4 new i18n keys (Chinese Traditional) |
+| `lib/i18n/locales/ja.js` | Modify | Add 4 new i18n keys (Japanese) |
+| `lib/i18n/locales/ko.js` | Modify | Add 4 new i18n keys (Korean) |
+| `lib/i18n/locales/de.js` | Modify | Add 4 new i18n keys (German) |
+| `lib/i18n/locales/fr.js` | Modify | Add 4 new i18n keys (French) |
+| `lib/i18n/locales/es.js` | Modify | Add 4 new i18n keys (Spanish) |
+| `lib/i18n/locales/it.js` | Modify | Add 4 new i18n keys (Italian) |
+| `lib/i18n/locales/pt.js` | Modify | Add 4 new i18n keys (Portuguese) |
+| `lib/i18n/locales/ru.js` | Modify | Add 4 new i18n keys (Russian) |
+| `test/providers.test.js` | Create | Tests for updated provider configs |
+| `test/menu-hints.test.js` | Create | Tests for hintCallback rendering |
+
+---
+
+### Task 1: Update GLM model presets (zhipu + zai)
+
+**Files:**
+- Modify: `lib/presets/providers.js:122-169` (zhipu and zai provider blocks)
+
+- [ ] **Step 1: Update zhipu provider**
+
+In `lib/presets/providers.js`, replace the `zhipu` block (lines 122–145):
+
+```js
+    zhipu: {
+        name: 'ZhiPu AI (GLM-5.1/5-Turbo/5/4.7) - 智谱清言',
+        baseUrl: 'https://open.bigmodel.cn/api/anthropic',
+        models: [
+            'glm-5.1',
+            'glm-5-turbo',
+            'glm-5',
+            'glm-4.7'
+        ],
+        versionAliases: {
+            'glm-4.5': 'glm-5.1',
+            'glm-4.6': 'glm-5.1'
+        },
+        authTokenFormat: 'sk-...',
+        description: 'ZhiPu AI (智谱清言) - Anthropic-compatible API for mainland China',
+        requiresToken: true,
+        compatibility: 'anthropic-compatible',
+        envVars: {
+            API_TIMEOUT_MS: '3000000',
+            CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+        },
+        note: 'Requires extended timeout for large responses'
+    },
+```
+
+- [ ] **Step 2: Update zai provider**
+
+Replace the `zai` block (lines 146–169):
+
+```js
+    zai: {
+        name: 'Z.ai (GLM-5.1/5-Turbo/5/4.7) - ZhiPu Global',
+        baseUrl: 'https://api.z.ai/api/anthropic',
+        models: [
+            'glm-5.1',
+            'glm-5-turbo',
+            'glm-5',
+            'glm-4.7'
+        ],
+        versionAliases: {
+            'glm-4.5': 'glm-5.1',
+            'glm-4.6': 'glm-5.1'
+        },
+        authTokenFormat: 'sk-...',
+        description: 'Z.ai (ZhiPu AI Global) - Anthropic-compatible API for international users',
+        requiresToken: true,
+        compatibility: 'anthropic-compatible',
+        envVars: {
+            API_TIMEOUT_MS: '3000000',
+            CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+        },
+        note: 'Requires extended timeout for large responses'
+    },
+```
+
+- [ ] **Step 3: Verify — run node to check syntax**
+
+Run: `node -e "const p = require('./lib/presets/providers'); const z = p.getProvider('zhipu'); const a = p.getProvider('zai'); console.log(z.name, z.models); console.log(a.name, a.models);"`
+
+Expected output:
+```
+ZhiPu AI (GLM-5.1/5-Turbo/5/4.7) - 智谱清言 [ 'glm-5.1', 'glm-5-turbo', 'glm-5', 'glm-4.7' ]
+Z.ai (GLM-5.1/5-Turbo/5/4.7) - ZhiPu Global [ 'glm-5.1', 'glm-5-turbo', 'glm-5', 'glm-4.7' ]
+```
+
+- [ ] **Step 4: Verify versionAliases only map removed models**
+
+Run: `node -e "const p = require('./lib/presets/providers'); console.log('glm-4.5 ->', p.getLatestModel('glm-4.5', 'zhipu')); console.log('glm-4.6 ->', p.getLatestModel('glm-4.6', 'zhipu')); console.log('glm-5 ->', p.getLatestModel('glm-5', 'zhipu')); console.log('glm-5-turbo ->', p.getLatestModel('glm-5-turbo', 'zhipu')); console.log('glm-5.1 ->', p.getLatestModel('glm-5.1', 'zhipu'));"`
+
+Expected output:
+```
+glm-4.5 -> glm-5.1
+glm-4.6 -> glm-5.1
+glm-5 -> null
+glm-5-turbo -> null
+glm-5.1 -> null
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/presets/providers.js
+git commit -m "feat: update GLM models to 5.1/5-Turbo for zhipu and zai providers"
+```
+
+---
+
+### Task 2: Update Kimi model presets (moonshot)
+
+**Files:**
+- Modify: `lib/presets/providers.js:37-56` (moonshot provider block)
+
+- [ ] **Step 1: Update moonshot provider**
+
+Replace the `moonshot` block (lines 37–56):
+
+```js
+    moonshot: {
+        name: 'Moonshot AI (Kimi-K2.5/K2-Thinking)',
+        baseUrl: 'https://api.moonshot.cn/anthropic',
+        models: [
+            'kimi-k2.5',
+            'kimi-k2-thinking',
+            'kimi-k2-thinking-turbo'
+        ],
+        versionAliases: {
+            'kimi-k2-0711-preview': 'kimi-k2.5',
+            'kimi-k2-0905-preview': 'kimi-k2.5',
+            'kimi-k2-turbo-preview': 'kimi-k2.5'
+        },
+        authTokenFormat: 'sk-...',
+        description: 'Moonshot AI - Provides Anthropic-compatible API',
+        requiresToken: true,
+        compatibility: 'anthropic-compatible',
+        envVars: {
+            API_TIMEOUT_MS: '3000000',
+            CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+        },
+        note: 'Requires extended timeout for large responses'
+    },
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `node -e "const p = require('./lib/presets/providers'); const m = p.getProvider('moonshot'); console.log(m.name, m.models); console.log('k2-0711 ->', p.getLatestModel('kimi-k2-0711-preview', 'moonshot')); console.log('k2-thinking ->', p.getLatestModel('kimi-k2-thinking', 'moonshot'));"`
+
+Expected:
+```
+Moonshot AI (Kimi-K2.5/K2-Thinking) [ 'kimi-k2.5', 'kimi-k2-thinking', 'kimi-k2-thinking-turbo' ]
+k2-0711 -> kimi-k2.5
+k2-thinking -> null
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/presets/providers.js
+git commit -m "feat: update Kimi models to K2.5, remove preview versions"
+```
+
+---
+
+### Task 3: Update MiniMax model presets (minimax_cn + minimax_global)
+
+**Files:**
+- Modify: `lib/presets/providers.js:73-104` (minimax_cn and minimax_global blocks)
+
+- [ ] **Step 1: Update minimax_cn provider**
+
+Replace the `minimax_cn` block (lines 73–88):
+
+```js
+    minimax_cn: {
+        name: 'MiniMax CN (国内版)',
+        baseUrl: 'https://api.minimaxi.com/anthropic',
+        models: [
+            'MiniMax-M2.7',
+            'MiniMax-M2.5',
+            'MiniMax-M2.1'
+        ],
+        authTokenFormat: 'sk-...',
+        description: 'MiniMax AI - Anthropic-compatible API for China users',
+        requiresToken: true,
+        compatibility: 'anthropic-compatible',
+        envVars: {
+            API_TIMEOUT_MS: '3000000',
+            CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+        },
+        note: 'Requires extended timeout for large responses'
+    },
+```
+
+- [ ] **Step 2: Update minimax_global provider**
+
+Replace the `minimax_global` block (lines 89–104):
+
+```js
+    minimax_global: {
+        name: 'MiniMax Global (国际版)',
+        baseUrl: 'https://api.minimax.io/anthropic',
+        models: [
+            'MiniMax-M2.7',
+            'MiniMax-M2.5',
+            'MiniMax-M2.1'
+        ],
+        authTokenFormat: 'sk-...',
+        description: 'MiniMax AI - Anthropic-compatible API for international users',
+        requiresToken: true,
+        compatibility: 'anthropic-compatible',
+        envVars: {
+            API_TIMEOUT_MS: '3000000',
+            CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'
+        },
+        note: 'Requires extended timeout for large responses'
+    },
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `node -e "const p = require('./lib/presets/providers'); console.log(p.getProvider('minimax_cn').models); console.log(p.getProvider('minimax_global').models);"`
+
+Expected:
+```
+[ 'MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.1' ]
+[ 'MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.1' ]
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/presets/providers.js
+git commit -m "feat: add MiniMax M2.7 and M2.5 models"
+```
+
+---
+
+### Task 4: Write tests for provider model updates
+
+**Files:**
+- Create: `test/providers.test.js`
+
+- [ ] **Step 1: Create test directory and test file**
+
+Run: `mkdir -p test`
+
+Create `test/providers.test.js`:
+
+```js
+/**
+ * Tests for provider model configurations
+ * Verifies model lists, versionAliases, and upgrade detection invariants
+ */
+
+const assert = require('assert');
+const {
+    getProvider,
+    getLatestModel,
+    hasModelUpgrade,
+    getSuggestedModels
+} = require('../lib/presets/providers');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        passed++;
+        console.log(`  ✓ ${name}`);
+    } catch (e) {
+        failed++;
+        console.log(`  ✗ ${name}`);
+        console.log(`    ${e.message}`);
+    }
+}
+
+// ─── GLM (zhipu) ───
+
+test('zhipu: models list is correct', () => {
+    const p = getProvider('zhipu');
+    assert.deepStrictEqual(p.models, ['glm-5.1', 'glm-5-turbo', 'glm-5', 'glm-4.7']);
+});
+
+test('zhipu: name includes all current model families', () => {
+    const p = getProvider('zhipu');
+    assert.ok(p.name.includes('GLM-5.1'));
+    assert.ok(p.name.includes('5-Turbo'));
+});
+
+test('zhipu: removed glm-4.5 aliases to glm-5.1', () => {
+    assert.strictEqual(getLatestModel('glm-4.5', 'zhipu'), 'glm-5.1');
+});
+
+test('zhipu: removed glm-4.6 aliases to glm-5.1', () => {
+    assert.strictEqual(getLatestModel('glm-4.6', 'zhipu'), 'glm-5.1');
+});
+
+test('zhipu: existing glm-5 has NO alias (not deprecated)', () => {
+    assert.strictEqual(getLatestModel('glm-5', 'zhipu'), null);
+});
+
+test('zhipu: existing glm-5-turbo has NO alias (not deprecated)', () => {
+    assert.strictEqual(getLatestModel('glm-5-turbo', 'zhipu'), null);
+});
+
+test('zhipu: existing glm-4.7 has NO alias (not deprecated)', () => {
+    assert.strictEqual(getLatestModel('glm-4.7', 'zhipu'), null);
+});
+
+test('zhipu: latest glm-5.1 has NO alias', () => {
+    assert.strictEqual(getLatestModel('glm-5.1', 'zhipu'), null);
+});
+
+// ─── GLM (zai) — must mirror zhipu ───
+
+test('zai: models list matches zhipu', () => {
+    const z = getProvider('zhipu');
+    const a = getProvider('zai');
+    assert.deepStrictEqual(a.models, z.models);
+});
+
+test('zai: versionAliases matches zhipu', () => {
+    const z = getProvider('zhipu');
+    const a = getProvider('zai');
+    assert.deepStrictEqual(a.versionAliases, z.versionAliases);
+});
+
+// ─── Kimi (moonshot) ───
+
+test('moonshot: models list is correct', () => {
+    const p = getProvider('moonshot');
+    assert.deepStrictEqual(p.models, ['kimi-k2.5', 'kimi-k2-thinking', 'kimi-k2-thinking-turbo']);
+});
+
+test('moonshot: removed kimi-k2-0711-preview aliases to kimi-k2.5', () => {
+    assert.strictEqual(getLatestModel('kimi-k2-0711-preview', 'moonshot'), 'kimi-k2.5');
+});
+
+test('moonshot: removed kimi-k2-0905-preview aliases to kimi-k2.5', () => {
+    assert.strictEqual(getLatestModel('kimi-k2-0905-preview', 'moonshot'), 'kimi-k2.5');
+});
+
+test('moonshot: removed kimi-k2-turbo-preview aliases to kimi-k2.5', () => {
+    assert.strictEqual(getLatestModel('kimi-k2-turbo-preview', 'moonshot'), 'kimi-k2.5');
+});
+
+test('moonshot: existing kimi-k2-thinking has NO alias (not deprecated)', () => {
+    assert.strictEqual(getLatestModel('kimi-k2-thinking', 'moonshot'), null);
+});
+
+test('moonshot: existing kimi-k2-thinking-turbo has NO alias (not deprecated)', () => {
+    assert.strictEqual(getLatestModel('kimi-k2-thinking-turbo', 'moonshot'), null);
+});
+
+test('moonshot: latest kimi-k2.5 has NO alias', () => {
+    assert.strictEqual(getLatestModel('kimi-k2.5', 'moonshot'), null);
+});
+
+// ─── MiniMax ───
+
+test('minimax_cn: models list is correct', () => {
+    const p = getProvider('minimax_cn');
+    assert.deepStrictEqual(p.models, ['MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.1']);
+});
+
+test('minimax_cn: no versionAliases (all models are concurrent tiers)', () => {
+    const p = getProvider('minimax_cn');
+    assert.strictEqual(p.versionAliases, undefined);
+});
+
+test('minimax_global: models list matches minimax_cn', () => {
+    const cn = getProvider('minimax_cn');
+    const gl = getProvider('minimax_global');
+    assert.deepStrictEqual(gl.models, cn.models);
+});
+
+test('minimax_global: MiniMax-M2.1 has NO alias', () => {
+    assert.strictEqual(getLatestModel('MiniMax-M2.1', 'minimax_global'), null);
+});
+
+// ─── Unchanged providers — regression guard ───
+
+test('anthropic: models unchanged, includes claude-opus-4-6', () => {
+    const p = getProvider('anthropic');
+    assert.ok(p.models.includes('claude-opus-4-6'));
+    assert.ok(p.models.includes('claude-sonnet-4-5'));
+});
+
+test('anthropic: versionAliases still map opus series', () => {
+    assert.strictEqual(getLatestModel('claude-opus-4', 'anthropic'), 'claude-opus-4-6');
+});
+
+test('deepseek: models unchanged', () => {
+    const p = getProvider('deepseek');
+    assert.deepStrictEqual(p.models, ['deepseek-chat', 'deepseek-reasoner']);
+});
+
+test('kimi_for_coding: models unchanged', () => {
+    const p = getProvider('kimi_for_coding');
+    assert.deepStrictEqual(p.models, ['kimi-for-coding']);
+});
+
+// ─── Cross-cutting: no active model in versionAliases ───
+
+test('invariant: no provider has an active model as a versionAlias key', () => {
+    const { providers } = require('../lib/presets/providers');
+    for (const [id, provider] of Object.entries(providers)) {
+        if (!provider.versionAliases) continue;
+        for (const aliasKey of Object.keys(provider.versionAliases)) {
+            assert.ok(
+                !provider.models.includes(aliasKey),
+                `Provider "${id}": model "${aliasKey}" is both in models[] and versionAliases (would trigger unwanted upgrade)`
+            );
+        }
+    }
+});
+
+// ─── Summary ───
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);
+```
+
+- [ ] **Step 2: Run tests — verify they pass**
+
+Run: `node test/providers.test.js`
+
+Expected: All tests pass (0 failed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/providers.test.js
+git commit -m "test: add provider model config tests"
+```
+
+---
+
+### Task 5: Add `launchClaudeAutoMode()` to launcher
+
+**Files:**
+- Modify: `lib/launcher.js:182-184` (after `launchClaudeSkipPermissions`), `lib/launcher.js:352-358` (module.exports)
+
+- [ ] **Step 1: Add function**
+
+In `lib/launcher.js`, after the `launchClaudeSkipPermissions` function (after line 184), add:
+
+```js
+/**
+ * Launch Claude with auto mode enabled
+ * Note: --enable-auto-mode makes auto mode available as a permission mode.
+ * User must press Shift+Tab in the session to switch to it.
+ */
+function launchClaudeAutoMode() {
+    launchClaude('claude --enable-auto-mode');
+}
+```
+
+- [ ] **Step 2: Add to module.exports**
+
+In `lib/launcher.js`, update the `module.exports` block (line 352) to add `launchClaudeAutoMode`:
+
+```js
+module.exports = {
+    launchClaude,
+    launchClaudeDefault,
+    launchClaudeSkipPermissions,
+    launchClaudeAutoMode,
+    launchClaudeWithApi,
+    getProviderEnvVars,
+    testApiConnection
+};
+```
+
+- [ ] **Step 3: Verify — require and check it exists**
+
+Run: `node -e "const l = require('./lib/launcher'); console.log(typeof l.launchClaudeAutoMode);"`
+
+Expected: `function`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/launcher.js
+git commit -m "feat: add launchClaudeAutoMode() for --enable-auto-mode flag"
+```
+
+---
+
+### Task 6: Add hintCallback support to Menu class
+
+**Files:**
+- Modify: `lib/ui/menu.js:64-96` (`displayMenu` method), `lib/ui/menu.js:111-228` (`navigate` method)
+
+- [ ] **Step 1: Update `displayMenu` signature and rendering**
+
+In `lib/ui/menu.js`, change the `displayMenu` method signature (line 64) from:
+
+```js
+    displayMenu(clearScreen = true, versionInfo = null) {
+```
+
+to:
+
+```js
+    displayMenu(clearScreen = true, versionInfo = null, hintCallback = null) {
+```
+
+Then, at the end of `displayMenu`, replace the final `console.log('');` (line 95) with hint rendering logic:
+
+```js
+        // Render dynamic hint if callback provided
+        if (hintCallback) {
+            const hintText = hintCallback(this.selectedIndex);
+            if (hintText) {
+                console.log(colors.cyan + '  ℹ ' + colors.gray + hintText + colors.reset);
+            }
+        }
+
+        console.log('');
+```
+
+- [ ] **Step 2: Update `navigate` signature and pass-through**
+
+In `lib/ui/menu.js`, change the `navigate` method signature (line 111) from:
+
+```js
+    async navigate(clearScreen = true, versionInfo = null) {
+```
+
+to:
+
+```js
+    async navigate(clearScreen = true, versionInfo = null, hintCallback = null) {
+```
+
+Store hintCallback for redrawing — change line 118:
+
+```js
+        this.versionInfo = versionInfo; // Store for redrawing
+```
+
+to:
+
+```js
+        this.versionInfo = versionInfo; // Store for redrawing
+        this.hintCallback = hintCallback; // Store for redrawing
+```
+
+Update the initial `displayMenu` call (line 121):
+
+```js
+            this.displayMenu(clearScreen, versionInfo, hintCallback);
+```
+
+Update both arrow key cases in `handleKeyPress` (lines 173-174 and 178-179) to pass `hintCallback`:
+
+```js
+                            case '\u001b[A': // Up arrow
+                                this.selectedIndex = (this.selectedIndex - 1 + this.menuOptions.length) % this.menuOptions.length;
+                                this.displayMenu(true, this.versionInfo, this.hintCallback);
+                                break;
+
+                            case '\u001b[B': // Down arrow
+                                this.selectedIndex = (this.selectedIndex + 1) % this.menuOptions.length;
+                                this.displayMenu(true, this.versionInfo, this.hintCallback);
+                                break;
+```
+
+- [ ] **Step 3: Verify — require and check no syntax errors**
+
+Run: `node -e "const Menu = require('./lib/ui/menu'); const m = new Menu(); console.log(typeof m.displayMenu, typeof m.navigate);"`
+
+Expected: `function function`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/ui/menu.js
+git commit -m "feat: add hintCallback support to Menu.displayMenu() and navigate()"
+```
+
+---
+
+### Task 7: Write tests for menu hint rendering
+
+**Files:**
+- Create: `test/menu-hints.test.js`
+
+- [ ] **Step 1: Create test file**
+
+Create `test/menu-hints.test.js`:
+
+```js
+/**
+ * Tests for Menu hintCallback rendering
+ * Captures console.log output to verify hint behavior
+ */
+
+const assert = require('assert');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        passed++;
+        console.log(`  ✓ ${name}`);
+    } catch (e) {
+        failed++;
+        console.log(`  ✗ ${name}`);
+        console.log(`    ${e.message}`);
+    }
+}
+
+// Helper: capture console.log output during a function call
+function captureLog(fn) {
+    const logs = [];
+    const original = console.log;
+    const originalClear = console.clear;
+    console.log = (...args) => logs.push(args.join(' '));
+    console.clear = () => {}; // suppress clear
+    try {
+        fn();
+    } finally {
+        console.log = original;
+        console.clear = originalClear;
+    }
+    return logs;
+}
+
+const Menu = require('../lib/ui/menu');
+
+// ─── displayMenu with hintCallback ───
+
+test('displayMenu: no hint when hintCallback is null', () => {
+    const m = new Menu();
+    m.setOptions(['Option A', 'Option B']);
+    const logs = captureLog(() => m.displayMenu(false, null, null));
+    const hintLines = logs.filter(l => l.includes('ℹ'));
+    assert.strictEqual(hintLines.length, 0);
+});
+
+test('displayMenu: no hint when hintCallback returns null for selected index', () => {
+    const m = new Menu();
+    m.setOptions(['Option A', 'Option B']);
+    const cb = (idx) => idx === 1 ? 'Some hint' : null;
+    const logs = captureLog(() => m.displayMenu(false, null, cb));
+    // selectedIndex defaults to 0, callback returns null for 0
+    const hintLines = logs.filter(l => l.includes('ℹ'));
+    assert.strictEqual(hintLines.length, 0);
+});
+
+test('displayMenu: shows hint when hintCallback returns string for selected index', () => {
+    const m = new Menu();
+    m.setOptions(['Option A', 'Option B']);
+    m.selectedIndex = 1;
+    const cb = (idx) => idx === 1 ? 'Test hint text' : null;
+    const logs = captureLog(() => m.displayMenu(false, null, cb));
+    const hintLines = logs.filter(l => l.includes('ℹ') && l.includes('Test hint text'));
+    assert.strictEqual(hintLines.length, 1);
+});
+
+test('displayMenu: hint changes when selectedIndex changes', () => {
+    const m = new Menu();
+    m.setOptions(['A', 'B', 'C']);
+
+    const cb = (idx) => {
+        if (idx === 0) return 'Hint for A';
+        if (idx === 1) return 'Hint for B';
+        return null;
+    };
+
+    m.selectedIndex = 0;
+    const logs0 = captureLog(() => m.displayMenu(false, null, cb));
+    assert.ok(logs0.some(l => l.includes('Hint for A')));
+
+    m.selectedIndex = 1;
+    const logs1 = captureLog(() => m.displayMenu(false, null, cb));
+    assert.ok(logs1.some(l => l.includes('Hint for B')));
+
+    m.selectedIndex = 2;
+    const logs2 = captureLog(() => m.displayMenu(false, null, cb));
+    assert.ok(!logs2.some(l => l.includes('ℹ')));
+});
+
+test('displayMenu: backward compat — works without hintCallback', () => {
+    const m = new Menu();
+    m.setOptions(['Option A']);
+    // Call with only 2 args (old signature)
+    const logs = captureLog(() => m.displayMenu(false, null));
+    assert.ok(logs.length > 0); // rendered something
+    const hintLines = logs.filter(l => l.includes('ℹ'));
+    assert.strictEqual(hintLines.length, 0);
+});
+
+// ─── Summary ───
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);
+```
+
+- [ ] **Step 2: Run tests — verify they pass**
+
+Run: `node test/menu-hints.test.js`
+
+Expected: All tests pass (0 failed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/menu-hints.test.js
+git commit -m "test: add menu hintCallback rendering tests"
+```
+
+---
+
+### Task 8: Add i18n keys to all 11 locale files
+
+**Files:**
+- Modify: `lib/i18n/locales/en.js` (and 10 other locale files)
+
+The 4 new keys to add to every locale, nested under their existing parent objects:
+
+1. `menu.main.launch_auto_mode` — inside `menu.main { ... }`
+2. `hints.auto_mode_info` — new top-level `hints` object
+3. `hints.active_api_info` — inside `hints { ... }`
+4. `hints.no_active_api` — inside `hints { ... }`
+
+- [ ] **Step 1: Add keys to en.js**
+
+In `lib/i18n/locales/en.js`, inside `menu.main` (after the `launch_skip` line, around line 12), add:
+
+```js
+            launch_auto_mode: "Launch Claude Code (Enable Auto Mode)",
+```
+
+Then, add a new `hints` top-level section. Find a suitable location (e.g. after the `version` section near the end of the file) and add:
+
+```js
+    hints: {
+        auto_mode_info: 'Auto Mode: Currently supports Team plan. Enterprise/API rolling out. Use Shift+Tab to switch after launch.',
+        active_api_info: 'Active: {0} / {1}',
+        no_active_api: 'No active API configured. Go to "API Management" to add one.'
+    },
+```
+
+- [ ] **Step 2: Add keys to zh.js (Chinese Simplified)**
+
+In `menu.main`, after `launch_skip`:
+```js
+            launch_auto_mode: "启动 Claude Code（启用自动模式）",
+```
+
+New `hints` section:
+```js
+    hints: {
+        auto_mode_info: '自动模式：目前支持 Team 计划。Enterprise/API 计划逐步推出中。启动后按 Shift+Tab 切换。',
+        active_api_info: '当前激活：{0} / {1}',
+        no_active_api: '未配置激活的API，请前往"API管理"添加。'
+    },
+```
+
+- [ ] **Step 3: Add keys to zh-TW.js (Chinese Traditional)**
+
+In `menu.main`, after `launch_skip`:
+```js
+            launch_auto_mode: "啟動 Claude Code（啟用自動模式）",
+```
+
+New `hints` section:
+```js
+    hints: {
+        auto_mode_info: '自動模式：目前支援 Team 方案。Enterprise/API 方案逐步推出中。啟動後按 Shift+Tab 切換。',
+        active_api_info: '目前啟用：{0} / {1}',
+        no_active_api: '未設定啟用的API，請前往「API管理」新增。'
+    },
+```
+
+- [ ] **Step 4: Add keys to ja.js (Japanese)**
+
+In `menu.main`, after `launch_skip`:
+```js
+            launch_auto_mode: "Claude Code を起動（自動モード有効化）",
+```
+
+New `hints` section:
+```js
+    hints: {
+        auto_mode_info: '自動モード：現在 Team プランで利用可能。Enterprise/API プランは順次展開中。起動後 Shift+Tab で切替。',
+        active_api_info: 'アクティブ：{0} / {1}',
+        no_active_api: 'アクティブなAPIがありません。「API管理」から追加してください。'
+    },
+```
+
+- [ ] **Step 5: Add keys to ko.js (Korean)**
+
+In `menu.main`, after `launch_skip`:
+```js
+            launch_auto_mode: "Claude Code 실행 (자동 모드 활성화)",
+```
+
+New `hints` section:
+```js
+    hints: {
+        auto_mode_info: '자동 모드: 현재 Team 플랜에서 지원됩니다. Enterprise/API 플랜은 순차 출시 중입니다. 실행 후 Shift+Tab으로 전환하세요.',
+        active_api_info: '활성: {0} / {1}',
+        no_active_api: '활성화된 API가 없습니다. "API 관리"에서 추가하세요.'
+    },
+```
+
+- [ ] **Step 6: Add keys to de.js (German)**
+
+In `menu.main`, after `launch_skip`:
+```js
+            launch_auto_mode: "Claude Code starten (Auto-Modus aktivieren)",
+```
+
+New `hints` section:
+```js
+    hints: {
+        auto_mode_info: 'Auto-Modus: Derzeit fuer Team-Plan verfuegbar. Enterprise/API wird schrittweise eingefuehrt. Nach dem Start mit Shift+Tab wechseln.',
+        active_api_info: 'Aktiv: {0} / {1}',
+        no_active_api: 'Keine aktive API konfiguriert. Gehen Sie zur "API-Verwaltung", um eine hinzuzufuegen.'
+    },
+```
+
+- [ ] **Step 7: Add keys to fr.js (French)**
+
+In `menu.main`, after `launch_skip`:
+```js
+            launch_auto_mode: "Lancer Claude Code (Activer le mode auto)",
+```
+
+New `hints` section:
+```js
+    hints: {
+        auto_mode_info: 'Mode auto : Disponible pour le plan Team. Enterprise/API en cours de deploiement. Apres le lancement, appuyez sur Shift+Tab pour basculer.',
+        active_api_info: 'Actif : {0} / {1}',
+        no_active_api: 'Aucune API active configuree. Allez dans "Gestion des API" pour en ajouter une.'
+    },
+```
+
+- [ ] **Step 8: Add keys to es.js (Spanish)**
+
+In `menu.main`, after `launch_skip`:
+```js
+            launch_auto_mode: "Iniciar Claude Code (Activar modo automatico)",
+```
+
+New `hints` section:
+```js
+    hints: {
+        auto_mode_info: 'Modo automatico: Disponible para el plan Team. Enterprise/API en despliegue gradual. Despues de iniciar, presione Shift+Tab para cambiar.',
+        active_api_info: 'Activo: {0} / {1}',
+        no_active_api: 'No hay API activa configurada. Vaya a "Gestion de API" para agregar una.'
+    },
+```
+
+- [ ] **Step 9: Add keys to it.js (Italian)**
+
+In `menu.main`, after `launch_skip`:
+```js
+            launch_auto_mode: "Avvia Claude Code (Abilita modalita automatica)",
+```
+
+New `hints` section:
+```js
+    hints: {
+        auto_mode_info: 'Modalita automatica: Attualmente disponibile per il piano Team. Enterprise/API in fase di rilascio graduale. Dopo l\'avvio, premi Shift+Tab per passare.',
+        active_api_info: 'Attivo: {0} / {1}',
+        no_active_api: 'Nessuna API attiva configurata. Vai a "Gestione API" per aggiungerne una.'
+    },
+```
+
+- [ ] **Step 10: Add keys to pt.js (Portuguese)**
+
+In `menu.main`, after `launch_skip`:
+```js
+            launch_auto_mode: "Iniciar Claude Code (Ativar modo automatico)",
+```
+
+New `hints` section:
+```js
+    hints: {
+        auto_mode_info: 'Modo automatico: Disponivel para o plano Team. Enterprise/API em implantacao gradual. Apos iniciar, pressione Shift+Tab para alternar.',
+        active_api_info: 'Ativo: {0} / {1}',
+        no_active_api: 'Nenhuma API ativa configurada. Va para "Gerenciamento de API" para adicionar uma.'
+    },
+```
+
+- [ ] **Step 11: Add keys to ru.js (Russian)**
+
+In `menu.main`, after `launch_skip`:
+```js
+            launch_auto_mode: "Запустить Claude Code (Включить авторежим)",
+```
+
+New `hints` section:
+```js
+    hints: {
+        auto_mode_info: 'Авторежим: Доступен для плана Team. Enterprise/API постепенно внедряются. После запуска нажмите Shift+Tab для переключения.',
+        active_api_info: 'Активный: {0} / {1}',
+        no_active_api: 'Нет настроенного активного API. Перейдите в "Управление API", чтобы добавить.'
+    },
+```
+
+- [ ] **Step 12: Verify — load all locales without errors**
+
+Run: `node -e "const locales = ['en','zh','zh-TW','ja','ko','de','fr','es','it','pt','ru']; locales.forEach(l => { const m = require('./lib/i18n/locales/' + l); console.log(l + ': launch_auto_mode=' + (m.menu.main.launch_auto_mode ? 'OK' : 'MISSING') + ', hints=' + (m.hints ? 'OK' : 'MISSING')); });"`
+
+Expected: all 11 lines show `launch_auto_mode=OK, hints=OK`.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add lib/i18n/locales/
+git commit -m "feat: add i18n keys for auto mode menu and dynamic hints (11 locales)"
+```
+
+---
+
+### Task 9: Wire auto mode + hints + index shift in main file
+
+**Files:**
+- Modify: `claude-launcher:46-50` (import), `claude-launcher:1092-1105` (menu options + navigate call), `claude-launcher:960-997` (executeSelection switch)
+
+This is the largest task — it wires everything together.
+
+- [ ] **Step 1: Add `launchClaudeAutoMode` to import**
+
+In `claude-launcher`, update the launcher require block (lines 46-50) from:
+
+```js
+const {
+    launchClaudeDefault,
+    launchClaudeSkipPermissions,
+    launchClaudeWithApi
+} = require('./lib/launcher');
+```
+
+to:
+
+```js
+const {
+    launchClaudeDefault,
+    launchClaudeSkipPermissions,
+    launchClaudeAutoMode,
+    launchClaudeWithApi
+} = require('./lib/launcher');
+```
+
+- [ ] **Step 2: Add menu option at index 2 and build hintCallback**
+
+In `claude-launcher`, replace the menu options block (lines 1092-1105):
+
+```js
+    // Populate menu options dynamically with i18n translations
+    menuOptions = [
+        await i18n.t('menu.main.launch_default'),
+        await i18n.t('menu.main.launch_skip'),
+        await i18n.t('menu.main.launch_api'),
+        await i18n.t('menu.main.launch_api_skip'),
+        await i18n.t('menu.main.api_management'),
+        await i18n.t('menu.main.language_settings'),
+        await i18n.t('menu.main.version_check'),
+        await i18n.t('menu.main.exit')
+    ];
+
+    globalMainMenu.setOptions(menuOptions);
+    const selection = await globalMainMenu.navigate(false, displayInfo || null); // Pass combined info to display between banner and nav
+```
+
+with:
+
+```js
+    // Populate menu options dynamically with i18n translations
+    menuOptions = [
+        await i18n.t('menu.main.launch_default'),
+        await i18n.t('menu.main.launch_skip'),
+        await i18n.t('menu.main.launch_auto_mode'),
+        await i18n.t('menu.main.launch_api'),
+        await i18n.t('menu.main.launch_api_skip'),
+        await i18n.t('menu.main.api_management'),
+        await i18n.t('menu.main.language_settings'),
+        await i18n.t('menu.main.version_check'),
+        await i18n.t('menu.main.exit')
+    ];
+
+    // Pre-compute hint texts synchronously for menu callback
+    const hintAutoMode = i18n.tSync('hints.auto_mode_info');
+    const activeApi = apiManager.getActiveApi();
+    let hintApiInfo = null;
+    if (activeApi) {
+        const { getProvider } = require('./lib/presets/providers');
+        const providerConfig = getProvider(activeApi.provider);
+        const providerName = providerConfig ? providerConfig.name : (activeApi.provider || 'Custom');
+        hintApiInfo = i18n.tSync('hints.active_api_info', providerName, activeApi.model);
+    } else {
+        hintApiInfo = i18n.tSync('hints.no_active_api');
+    }
+
+    // Synchronous hint callback — must not use await
+    const hintCallback = (selectedIndex) => {
+        switch (selectedIndex) {
+            case 2: return hintAutoMode;
+            case 3: return hintApiInfo;
+            case 4: return hintApiInfo;
+            default: return null;
+        }
+    };
+
+    globalMainMenu.setOptions(menuOptions);
+    const selection = await globalMainMenu.navigate(false, displayInfo || null, hintCallback);
+```
+
+- [ ] **Step 3: Update executeSelection switch — shift all indices**
+
+In `claude-launcher`, replace the `executeSelection` function (lines 960-997):
+
+```js
+async function executeSelection(selectedIndex) {
+    switch (selectedIndex) {
+        case 0: // Launch Claude Code
+            launchClaudeDefault();
+            break;
+
+        case 1: // Launch Claude Code (Skip Permissions)
+            launchClaudeSkipPermissions();
+            break;
+
+        case 2: // Launch Claude Code with 3rd-party API
+            await handleThirdPartyApiLaunch(false);
+            break;
+
+        case 3: // Launch Claude Code with 3rd-party API (Skip Permissions)
+            await handleThirdPartyApiLaunch(true);
+            break;
+
+        case 4: // 3rd-party API Management
+            return await showApiManagementMenu();
+
+        case 5: // Language Settings
+            return await showLanguageSettings();
+
+        case 6: // Version Update Check
+            return await showVersionUpdateCheck();
+
+        case 7: // Exit
+            console.log('');
+            console.log(colors.green + '👋 ' + await i18n.t('menu.main.exit') + '!' + colors.reset);
+            process.exit(0);
+            break;
+
+        default:
+            showMenu();
+            break;
+    }
+}
+```
+
+with:
+
+```js
+async function executeSelection(selectedIndex) {
+    switch (selectedIndex) {
+        case 0: // Launch Claude Code
+            launchClaudeDefault();
+            break;
+
+        case 1: // Launch Claude Code (Skip Permissions)
+            launchClaudeSkipPermissions();
+            break;
+
+        case 2: // Launch Claude Code (Enable Auto Mode)
+            launchClaudeAutoMode();
+            break;
+
+        case 3: // Launch Claude Code with 3rd-party API
+            await handleThirdPartyApiLaunch(false);
+            break;
+
+        case 4: // Launch Claude Code with 3rd-party API (Skip Permissions)
+            await handleThirdPartyApiLaunch(true);
+            break;
+
+        case 5: // 3rd-party API Management
+            return await showApiManagementMenu();
+
+        case 6: // Language Settings
+            return await showLanguageSettings();
+
+        case 7: // Version Update Check
+            return await showVersionUpdateCheck();
+
+        case 8: // Exit
+            console.log('');
+            console.log(colors.green + '👋 ' + await i18n.t('menu.main.exit') + '!' + colors.reset);
+            process.exit(0);
+            break;
+
+        default:
+            showMenu();
+            break;
+    }
+}
+```
+
+- [ ] **Step 4: Verify — syntax check the main file**
+
+Run: `node -e "try { require('./claude-launcher'); } catch(e) { if (e.code === 'MODULE_NOT_FOUND') console.log('ERROR:', e.message); else console.log('OK: file parses'); }"`
+
+Note: The main file will try to run the launcher and may fail on stdin/TTY in a non-interactive context, but any `SyntaxError` would be caught. A better check:
+
+Run: `node --check claude-launcher`
+
+Expected: No output (no syntax errors).
+
+- [ ] **Step 5: Run all tests**
+
+Run: `node test/providers.test.js && node test/menu-hints.test.js`
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add claude-launcher
+git commit -m "feat: add auto mode menu item, dynamic hints, and shift menu indices"
+```
+
+---
+
+### Task 10: Manual smoke test
+
+- [ ] **Step 1: Launch the app**
+
+Run: `node claude-launcher`
+
+- [ ] **Step 2: Verify menu shows 9 items** (0-8)
+
+Check that "Launch Claude Code (Enable Auto Mode)" appears at position 2 (or the translated equivalent if not English).
+
+- [ ] **Step 3: Arrow down to "Enable Auto Mode" — verify hint appears below menu**
+
+Expected: A line like `ℹ Auto Mode: Currently supports Team plan...` appears below the menu options.
+
+- [ ] **Step 4: Arrow to 3rd-party API option — verify hint changes**
+
+Expected: Either shows `ℹ Active: {provider} / {model}` or `ℹ No active API configured...` depending on whether an API is configured.
+
+- [ ] **Step 5: Arrow to other items (default launch, exit) — verify no hint**
+
+Expected: Hint line disappears.
+
+- [ ] **Step 6: Press Escape to exit**
+
+- [ ] **Step 7: Final commit (if any fixes needed)**
+
+```bash
+git add -A
+git commit -m "fix: smoke test adjustments"
+```
+
+(Skip this commit if no fixes were needed.)

--- a/docs/superpowers/plans/2026-03-31-update-models-and-auto-mode.md
+++ b/docs/superpowers/plans/2026-03-31-update-models-and-auto-mode.md
@@ -724,70 +724,178 @@ test('displayMenu: backward compat — works without hintCallback', () => {
     assert.strictEqual(hintLines.length, 0);
 });
 
-// ─── navigate() stores and passes through hintCallback ───
+// ─── navigate() pass-through and arrow-key redraw ───
+// These tests call navigate() for real with a stubbed stdinManager,
+// then inject arrow keys and Enter to drive the menu and capture output.
 
-test('navigate: stores hintCallback on instance', () => {
+const EventEmitter = require('events');
+const stdinManager = require('../lib/utils/stdin-manager');
+
+// Helper: create a fake StdinScope that records 'data' handlers
+// and allows us to inject key sequences
+function createFakeScope() {
+    const emitter = new EventEmitter();
+    emitter.release = () => {};
+    emitter.removeListener = (ev, fn) => emitter.off(ev, fn);
+    return emitter;
+}
+
+// Helper: run an async test (navigate returns a Promise)
+function asyncTest(name, fn) {
+    const p = fn().then(() => {
+        passed++;
+        console.log(`  ✓ ${name}`);
+    }).catch((e) => {
+        failed++;
+        console.log(`  ✗ ${name}`);
+        console.log(`    ${e.message}`);
+    });
+    return p;
+}
+
+// We need process.stdin.isTTY = true for navigate() to use raw mode path
+const origIsTTY = process.stdin.isTTY;
+
+const allAsync = Promise.resolve()
+
+.then(() => asyncTest('navigate: accepts hintCallback 3rd param and renders hint on initial draw', async () => {
+    const fakeScope = createFakeScope();
+    const origAcquire = stdinManager.acquire.bind(stdinManager);
+    stdinManager.acquire = () => fakeScope;
+    process.stdin.isTTY = true;
+
     const m = new Menu();
     m.setOptions(['A', 'B']);
-    const cb = (idx) => idx === 0 ? 'hint' : null;
-    // We can't fully run navigate() (it blocks on stdin), but we can
-    // verify the storage path by calling displayMenu via navigate's
-    // internal contract. Simulate what navigate does before blocking:
-    m.versionInfo = 'v1';
-    m.hintCallback = cb;
-    // After navigate() stores these, arrow key redraws call:
-    //   this.displayMenu(true, this.versionInfo, this.hintCallback)
-    // Verify this path renders the hint:
-    m.selectedIndex = 0;
-    const logs = captureLog(() => m.displayMenu(true, m.versionInfo, m.hintCallback));
-    assert.ok(logs.some(l => l.includes('hint')));
-});
+    const cb = (idx) => idx === 0 ? 'Initial hint' : null;
 
-test('navigate: arrow key redraw uses stored hintCallback (simulated)', () => {
+    let initialLogs = [];
+    const origLog = console.log;
+    const origClear = console.clear;
+    console.log = (...args) => initialLogs.push(args.join(' '));
+    console.clear = () => {};
+
+    const navPromise = m.navigate(false, null, cb);
+
+    // navigate() has now called displayMenu and registered the handler
+    // Capture is already in initialLogs. Resolve by sending Enter.
+    console.log = origLog;
+    console.clear = origClear;
+
+    fakeScope.emit('data', '\r'); // Enter → resolve
+    await navPromise;
+
+    stdinManager.acquire = origAcquire;
+    process.stdin.isTTY = origIsTTY;
+
+    assert.ok(initialLogs.some(l => l.includes('Initial hint')),
+        'Initial displayMenu call should render hint from callback');
+}))
+
+.then(() => asyncTest('navigate: arrow key redraw passes stored hintCallback', async () => {
+    const fakeScope = createFakeScope();
+    const origAcquire = stdinManager.acquire.bind(stdinManager);
+    stdinManager.acquire = () => fakeScope;
+    process.stdin.isTTY = true;
+
     const m = new Menu();
     m.setOptions(['A', 'B', 'C']);
     const cb = (idx) => {
         if (idx === 1) return 'Hint for B';
         return null;
     };
-    // Simulate what navigate() stores
-    m.versionInfo = null;
-    m.hintCallback = cb;
 
-    // Simulate up arrow: selectedIndex moves to 1
-    m.selectedIndex = 1;
-    const logs1 = captureLog(() => m.displayMenu(true, m.versionInfo, m.hintCallback));
-    assert.ok(logs1.some(l => l.includes('Hint for B')), 'Should show hint after arrow to index 1');
+    // Suppress initial draw
+    const origLog = console.log;
+    const origClear = console.clear;
+    console.log = () => {};
+    console.clear = () => {};
 
-    // Simulate another arrow: selectedIndex moves to 2
-    m.selectedIndex = 2;
-    const logs2 = captureLog(() => m.displayMenu(true, m.versionInfo, m.hintCallback));
-    assert.ok(!logs2.some(l => l.includes('ℹ')), 'Should hide hint after arrow to index 2');
-});
+    const navPromise = m.navigate(false, null, cb);
 
-test('navigate: hintCallback defaults to null when not provided', () => {
+    // Now inject Down arrow and capture the redraw
+    let downLogs = [];
+    console.log = (...args) => downLogs.push(args.join(' '));
+    fakeScope.emit('data', '\u001b[B'); // Down → index 1
+
+    console.log = origLog;
+    console.clear = origClear;
+
+    assert.ok(downLogs.some(l => l.includes('Hint for B')),
+        'After arrow down to index 1, hint should show "Hint for B"');
+
+    // Arrow down again to index 2 (no hint)
+    let downLogs2 = [];
+    console.log = (...args) => downLogs2.push(args.join(' '));
+    console.clear = () => {};
+    fakeScope.emit('data', '\u001b[B'); // Down → index 2
+    console.log = origLog;
+    console.clear = origClear;
+
+    assert.ok(!downLogs2.some(l => l.includes('ℹ')),
+        'After arrow down to index 2, no hint should appear');
+
+    // Resolve
+    console.log = () => {};
+    console.clear = () => {};
+    fakeScope.emit('data', '\r');
+    console.log = origLog;
+    console.clear = origClear;
+    await navPromise;
+
+    stdinManager.acquire = origAcquire;
+    process.stdin.isTTY = origIsTTY;
+}))
+
+.then(() => asyncTest('navigate: without hintCallback (2 args), no hint rendered on arrow', async () => {
+    const fakeScope = createFakeScope();
+    const origAcquire = stdinManager.acquire.bind(stdinManager);
+    stdinManager.acquire = () => fakeScope;
+    process.stdin.isTTY = true;
+
     const m = new Menu();
-    m.setOptions(['A']);
-    // Simulate navigate(false, 'info') without 3rd arg
-    m.versionInfo = 'info';
-    m.hintCallback = null; // default
-    m.selectedIndex = 0;
-    const logs = captureLog(() => m.displayMenu(true, m.versionInfo, m.hintCallback));
-    const hintLines = logs.filter(l => l.includes('ℹ'));
-    assert.strictEqual(hintLines.length, 0);
+    m.setOptions(['A', 'B']);
+
+    const origLog = console.log;
+    const origClear = console.clear;
+    console.log = () => {};
+    console.clear = () => {};
+
+    // Call with only 2 args (old contract)
+    const navPromise = m.navigate(false, null);
+
+    let downLogs = [];
+    console.log = (...args) => downLogs.push(args.join(' '));
+    fakeScope.emit('data', '\u001b[B'); // Down
+    console.log = origLog;
+    console.clear = origClear;
+
+    assert.ok(!downLogs.some(l => l.includes('ℹ')),
+        'Without hintCallback, no hint should appear on arrow');
+
+    console.log = () => {};
+    console.clear = () => {};
+    fakeScope.emit('data', '\r');
+    console.log = origLog;
+    console.clear = origClear;
+    await navPromise;
+
+    stdinManager.acquire = origAcquire;
+    process.stdin.isTTY = origIsTTY;
+}));
+
+// ─── Summary (after async tests complete) ───
+
+allAsync.then(() => {
+    console.log(`\n  ${passed} passed, ${failed} failed\n`);
+    if (failed > 0) process.exit(1);
 });
-
-// ─── Summary ───
-
-console.log(`\n  ${passed} passed, ${failed} failed\n`);
-if (failed > 0) process.exit(1);
 ```
 
 - [ ] **Step 2: Run tests — verify they pass**
 
 Run: `node test/menu-hints.test.js`
 
-Expected: All tests pass (0 failed).
+Expected: All tests pass (0 failed). The async navigate() tests run after the sync displayMenu() tests.
 
 - [ ] **Step 3: Commit**
 

--- a/docs/superpowers/specs/2026-03-31-update-models-and-auto-mode-design.md
+++ b/docs/superpowers/specs/2026-03-31-update-models-and-auto-mode-design.md
@@ -130,6 +130,8 @@ navigate(clearScreen = true, versionInfo = null, hintCallback = null)
 
 This preserves backward compatibility with all existing call sites that pass `(clearScreen, versionInfo)`.
 
+**Sync constraint:** `hintCallback` must be a **synchronous** function returning `string | null`. The menu redraws synchronously inside the raw-mode keypress handler (`lib/ui/menu.js` handleKeyPress), which has no `await` space. Hint text must be pre-computed before calling `navigate()`, or the callback must use only `i18n.tSync()` / cached data — never `await i18n.t()`.
+
 **Rendering:** If `hintCallback` is provided and `hintCallback(this.selectedIndex)` returns a non-null string, the Menu rendering layer prepends the `ℹ` icon with `colors.cyan` and renders the hint text in `colors.gray` below the menu options. If it returns null, no hint line is rendered. **Locale values must be pure text without the `ℹ` prefix** — the icon and color are added by Menu, not by i18n strings.
 
 ### 3.2 Hint Rules

--- a/docs/superpowers/specs/2026-03-31-update-models-and-auto-mode-design.md
+++ b/docs/superpowers/specs/2026-03-31-update-models-and-auto-mode-design.md
@@ -1,0 +1,183 @@
+# Design: Update Models & Add Auto Mode
+
+**Date:** 2026-03-31
+**Branch:** `feature/update-models-and-auto-mode`
+**Scope:** Update GLM/Kimi/MiniMax model versions, add Claude Auto Mode menu item, add dynamic menu hints
+
+---
+
+## 1. Model Configuration Updates (`lib/presets/providers.js`)
+
+### 1.1 GLM (zhipu + zai)
+
+**Changes:** Add `glm-5.1`, `glm-5-turbo`; remove `glm-4.5`, `glm-4.6`; add versionAliases for removed models only.
+
+**Source:** [Z.AI Developer Docs - Using GLM-5.1](https://docs.z.ai/devpack/using5.1), confirmed available on Anthropic-compatible endpoint `https://api.z.ai/api/anthropic`.
+
+```js
+// Both zhipu and zai get identical model config:
+name: 'ZhiPu AI (GLM-5.1/5-Turbo/5/4.7) - 智谱清言',  // zhipu
+name: 'Z.ai (GLM-5.1/5-Turbo/5/4.7) - ZhiPu Global',   // zai
+models: ['glm-5.1', 'glm-5-turbo', 'glm-5', 'glm-4.7'],
+versionAliases: {
+    'glm-4.5': 'glm-5.1',   // removed from model list
+    'glm-4.6': 'glm-5.1'    // removed from model list
+}
+```
+
+Note: `glm-5-turbo`, `glm-5`, `glm-4.7` are distinct models offered concurrently by the provider ([docs](https://docs.z.ai/guides/llm/glm-5-turbo)). They are NOT deprecated and must NOT appear in versionAliases, otherwise auto-upgrade would silently rewrite a user's intentional model choice.
+
+### 1.2 Kimi (moonshot)
+
+**Changes:** Add `kimi-k2.5`; remove `kimi-k2-0711-preview`, `kimi-k2-0905-preview`, `kimi-k2-turbo-preview`; add versionAliases for removed models only.
+
+**Source:** [Kimi K2.5 Quickstart](https://platform.moonshot.cn/docs/guide/kimi-k2-5-quickstart)
+
+```js
+name: 'Moonshot AI (Kimi-K2.5/K2-Thinking)',
+models: ['kimi-k2.5', 'kimi-k2-thinking', 'kimi-k2-thinking-turbo'],
+versionAliases: {
+    'kimi-k2-0711-preview': 'kimi-k2.5',   // removed from model list
+    'kimi-k2-0905-preview': 'kimi-k2.5',   // removed from model list
+    'kimi-k2-turbo-preview': 'kimi-k2.5'   // removed from model list
+}
+```
+
+Note: `kimi-k2-thinking` and `kimi-k2-thinking-turbo` are distinct thinking models ([docs](https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model)), not deprecated. They must NOT appear in versionAliases.
+
+`kimi_for_coding` provider: no changes.
+
+### 1.3 MiniMax (minimax_cn + minimax_global)
+
+**Changes:** Add `MiniMax-M2.7`, `MiniMax-M2.5`; no versionAliases needed (all models remain selectable).
+
+**Source:** [MiniMax Anthropic API Docs](https://platform.minimax.io/docs/api-reference/text-anthropic-api)
+
+```js
+// minimax_cn
+name: 'MiniMax CN (国内版)',
+models: ['MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.1'],
+// No versionAliases - M2.1 and M2.5 are distinct tiers, not deprecated
+
+// minimax_global
+name: 'MiniMax Global (国际版)',
+models: ['MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.1'],
+// No versionAliases - same reason
+```
+
+Note: MiniMax offers M2.1, M2.5, and M2.7 as concurrent tiers with different price/performance profiles ([platform docs](https://platform.minimax.io/)). They are NOT deprecated and must NOT appear in versionAliases.
+
+### 1.4 Unchanged Providers
+
+- `anthropic`: No changes (existing versionAliases handle multi-series upgrades correctly)
+- `deepseek`: No changes
+- `kimi_for_coding`: No changes
+- `custom`: No changes
+
+### 1.5 Upgrade Logic
+
+`getLatestModel()` and `hasModelUpgrade()` in `providers.js` remain unchanged. They continue to use `versionAliases` exclusively. The key invariant is: **versionAliases must only contain models that are truly removed/deprecated, never distinct models that the provider offers concurrently.**
+
+---
+
+## 2. Auto Mode Menu Item
+
+### 2.1 Background
+
+Claude Code auto mode (released March 24, 2026) uses a classifier-gated approval system. The `--enable-auto-mode` CLI flag **enables auto mode support** in a session, but does NOT start the session directly in auto mode. The user must press **Shift+Tab** to cycle to auto mode after launch. ([Source](https://claude.com/blog/auto-mode))
+
+Plan support: Currently available on Team plans. Enterprise and API plan support is rolling out.
+
+### 2.2 New Menu Structure
+
+```
+0: Launch Claude Code
+1: Launch Claude Code (Skip Permissions)
+2: Launch Claude Code (Enable Auto Mode)       <-- NEW (note: "Enable", not just "Auto Mode")
+3: Launch Claude Code with 3rd-party API
+4: Launch Claude Code with 3rd-party API (Auto Skip Permissions)
+5: 3rd-party API Management
+6: Language Settings
+7: Version Update Check
+8: Exit
+```
+
+### 2.3 Launch Implementation (`lib/launcher.js`)
+
+New function `launchClaudeAutoMode()`:
+- Command: `claude --enable-auto-mode`
+- Uses existing `launchClaude()` core with the new command string
+- This enables auto mode as a selectable permission mode; user switches to it with Shift+Tab in session
+
+### 2.4 Main File Changes (`claude-launcher`)
+
+- Add new menu option at index 2
+- Shift all subsequent menu indices by 1
+- Add case handler for index 2 calling `launchClaudeAutoMode()`
+
+---
+
+## 3. Dynamic Menu Hints
+
+### 3.1 Menu Class Changes (`lib/ui/menu.js`)
+
+**Parameter contract preservation:** Current signatures are `displayMenu(clearScreen, versionInfo)` and `navigate(clearScreen, versionInfo)`. The `hintCallback` parameter is added as the **third** parameter to both methods:
+
+```js
+displayMenu(clearScreen = true, versionInfo = null, hintCallback = null)
+navigate(clearScreen = true, versionInfo = null, hintCallback = null)
+```
+
+This preserves backward compatibility with all existing call sites that pass `(clearScreen, versionInfo)`.
+
+**Rendering:** If `hintCallback` is provided and `hintCallback(this.selectedIndex)` returns a non-null string, render it below the menu options with `colors.cyan` prefix `ℹ` icon. If it returns null, no hint line is rendered.
+
+### 3.2 Hint Rules
+
+| Selected Index | Hint Content |
+|---|---|
+| 0 (Default Launch) | No hint |
+| 1 (Skip Permissions) | No hint |
+| 2 (Enable Auto Mode) | `"ℹ Auto Mode: Currently supports Team plan. Enterprise/API rolling out. Use Shift+Tab to switch after launch."` |
+| 3 (3rd-party API) | Active API exists: `"ℹ Active: {providerName} / {model}"`; No API: `"ℹ No active API configured. Go to 'API Management' to add one."` |
+| 4 (3rd-party + Skip) | Same as index 3 |
+| 5-8 | No hint |
+
+### 3.3 Hint i18n
+
+All hint strings go through the i18n system with new keys:
+- `hints.auto_mode_info` - Auto Mode plan support + Shift+Tab instruction
+- `hints.active_api_info` - Active API info hint (with `{provider}` and `{model}` placeholders)
+- `hints.no_active_api` - No API configured hint
+
+---
+
+## 4. i18n Updates
+
+All 11 locale files need new entries:
+
+- `menu.main.launch_auto_mode` - Menu item text for "Launch Claude Code (Enable Auto Mode)"
+- `hints.auto_mode_info` - Auto Mode plan support + usage hint
+- `hints.active_api_info` - Active API info hint (with `{provider}` and `{model}` placeholders)
+- `hints.no_active_api` - No API configured hint
+
+---
+
+## 5. Files to Modify
+
+| File | Changes |
+|---|---|
+| `lib/presets/providers.js` | Update models, names, versionAliases for GLM/Kimi/MiniMax (deprecations only) |
+| `lib/ui/menu.js` | Add `hintCallback` as **3rd parameter** to `displayMenu()` and `navigate()` |
+| `lib/launcher.js` | Add `launchClaudeAutoMode()` function |
+| `claude-launcher` (main) | New menu item, hint callback, case handler, index shifts |
+| `lib/i18n/locales/*.js` (x11) | New i18n keys for Auto Mode menu and hints |
+
+---
+
+## 6. Out of Scope
+
+- No changes to `getLatestModel()` / `hasModelUpgrade()` logic
+- No new `latestModel` field
+- No changes to DeepSeek, Anthropic, kimi_for_coding, or custom providers
+- No changes to the model upgrade checker or auto-upgrade flow

--- a/docs/superpowers/specs/2026-03-31-update-models-and-auto-mode-design.md
+++ b/docs/superpowers/specs/2026-03-31-update-models-and-auto-mode-design.md
@@ -130,25 +130,27 @@ navigate(clearScreen = true, versionInfo = null, hintCallback = null)
 
 This preserves backward compatibility with all existing call sites that pass `(clearScreen, versionInfo)`.
 
-**Rendering:** If `hintCallback` is provided and `hintCallback(this.selectedIndex)` returns a non-null string, render it below the menu options with `colors.cyan` prefix `ℹ` icon. If it returns null, no hint line is rendered.
+**Rendering:** If `hintCallback` is provided and `hintCallback(this.selectedIndex)` returns a non-null string, the Menu rendering layer prepends the `ℹ` icon with `colors.cyan` and renders the hint text in `colors.gray` below the menu options. If it returns null, no hint line is rendered. **Locale values must be pure text without the `ℹ` prefix** — the icon and color are added by Menu, not by i18n strings.
 
 ### 3.2 Hint Rules
 
-| Selected Index | Hint Content |
+| Selected Index | Hint text returned by hintCallback (no icon prefix) |
 |---|---|
-| 0 (Default Launch) | No hint |
-| 1 (Skip Permissions) | No hint |
-| 2 (Enable Auto Mode) | `"ℹ Auto Mode: Currently supports Team plan. Enterprise/API rolling out. Use Shift+Tab to switch after launch."` |
-| 3 (3rd-party API) | Active API exists: `"ℹ Active: {providerName} / {model}"`; No API: `"ℹ No active API configured. Go to 'API Management' to add one."` |
+| 0 (Default Launch) | `null` (no hint) |
+| 1 (Skip Permissions) | `null` (no hint) |
+| 2 (Enable Auto Mode) | `"Auto Mode: Currently supports Team plan. Enterprise/API rolling out. Use Shift+Tab to switch after launch."` |
+| 3 (3rd-party API) | Active API exists: `"Active: ZhiPu AI / glm-5.1"` (formatted from i18n); No API: `"No active API configured. Go to 'API Management' to add one."` |
 | 4 (3rd-party + Skip) | Same as index 3 |
-| 5-8 | No hint |
+| 5-8 | `null` (no hint) |
 
 ### 3.3 Hint i18n
 
-All hint strings go through the i18n system with new keys:
-- `hints.auto_mode_info` - Auto Mode plan support + Shift+Tab instruction
-- `hints.active_api_info` - Active API info hint (with `{provider}` and `{model}` placeholders)
-- `hints.no_active_api` - No API configured hint
+All hint strings go through the i18n system. **Placeholders use positional `{0}`, `{1}` format** to match the existing `MessageFormatter.format()` in `lib/i18n/formatter.js`. Locale values must NOT include the `ℹ` icon prefix.
+
+New keys:
+- `hints.auto_mode_info` — e.g. `'Auto Mode: Currently supports Team plan. Enterprise/API rolling out. Use Shift+Tab to switch after launch.'`
+- `hints.active_api_info` — e.g. `'Active: {0} / {1}'` (where `{0}` = provider name, `{1}` = model)
+- `hints.no_active_api` — e.g. `'No active API configured. Go to "API Management" to add one.'`
 
 ---
 
@@ -157,9 +159,9 @@ All hint strings go through the i18n system with new keys:
 All 11 locale files need new entries:
 
 - `menu.main.launch_auto_mode` - Menu item text for "Launch Claude Code (Enable Auto Mode)"
-- `hints.auto_mode_info` - Auto Mode plan support + usage hint
-- `hints.active_api_info` - Active API info hint (with `{provider}` and `{model}` placeholders)
-- `hints.no_active_api` - No API configured hint
+- `hints.auto_mode_info` - Pure text, no icon prefix
+- `hints.active_api_info` - Uses `{0}` for provider name, `{1}` for model name
+- `hints.no_active_api` - Pure text, no icon prefix
 
 ---
 

--- a/lib/i18n/locales/de.js
+++ b/lib/i18n/locales/de.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "Hauptmenü",
             launch_default: "Claude Code starten",
             launch_skip: "Claude Code starten (Berechtigungsprüfung überspringen)",
+            launch_auto_mode: "Claude Code starten (Auto-Modus aktivieren)",
             launch_api: "Claude Code mit Drittanbieter-API starten",
             launch_api_skip: "Claude Code mit Drittanbieter-API starten (Berechtigungsprüfung überspringen)",
             api_management: "Drittanbieter-API-Verwaltung",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "Upgrade abgeschlossen!",
         manual_stats_upgraded: "Upgegradet: {0}",
         manual_stats_skipped: "Übersprungen: {0} ({1} bereits aktuell, {2} keine Upgrade-Info)"
+    },
+    hints: {
+        auto_mode_info: 'Auto-Modus: Derzeit fuer Team-Plan verfuegbar. Enterprise/API wird schrittweise eingefuehrt. Nach dem Start mit Shift+Tab wechseln.',
+        active_api_info: 'Aktiv: {0} / {1}',
+        no_active_api: 'Keine aktive API konfiguriert. Gehen Sie zur "API-Verwaltung", um eine hinzuzufuegen.'
     }
 };

--- a/lib/i18n/locales/en.js
+++ b/lib/i18n/locales/en.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "Main Menu",
             launch_default: "Launch Claude Code",
             launch_skip: "Launch Claude Code (Auto Skip Permissions)",
+            launch_auto_mode: "Launch Claude Code (Enable Auto Mode)",
             launch_api: "Launch Claude Code with 3rd-party API",
             launch_api_skip: "Launch Claude Code with 3rd-party API (Auto Skip Permissions)",
             api_management: "3rd-party API Management",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "Upgrade complete!",
         manual_stats_upgraded: "Upgraded: {0}",
         manual_stats_skipped: "Skipped: {0} ({1} already latest, {2} no upgrade info)"
+    },
+    hints: {
+        auto_mode_info: 'Auto Mode: Currently supports Team plan. Enterprise/API rolling out. Use Shift+Tab to switch after launch.',
+        active_api_info: 'Active: {0} / {1}',
+        no_active_api: 'No active API configured. Go to "API Management" to add one.'
     }
 };

--- a/lib/i18n/locales/es.js
+++ b/lib/i18n/locales/es.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "Menú Principal",
             launch_default: "Iniciar Claude Code",
             launch_skip: "Iniciar Claude Code (Omitir verificación de permisos)",
+            launch_auto_mode: "Iniciar Claude Code (Activar modo automatico)",
             launch_api: "Iniciar Claude Code con API de terceros",
             launch_api_skip: "Iniciar Claude Code con API de terceros (Omitir verificación de permisos)",
             api_management: "Gestión de API de terceros",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "¡Actualización completa!",
         manual_stats_upgraded: "Actualizados: {0}",
         manual_stats_skipped: "Omitidos: {0} ({1} ya actualizados, {2} sin info de actualización)"
+    },
+    hints: {
+        auto_mode_info: 'Modo automatico: Disponible para el plan Team. Enterprise/API en despliegue gradual. Despues de iniciar, presione Shift+Tab para cambiar.',
+        active_api_info: 'Activo: {0} / {1}',
+        no_active_api: 'No hay API activa configurada. Vaya a "Gestion de API" para agregar una.'
     }
 };

--- a/lib/i18n/locales/fr.js
+++ b/lib/i18n/locales/fr.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "Menu Principal",
             launch_default: "Lancer Claude Code",
             launch_skip: "Lancer Claude Code (Ignorer la vérification des permissions)",
+            launch_auto_mode: "Lancer Claude Code (Activer le mode auto)",
             launch_api: "Lancer Claude Code avec API tierce",
             launch_api_skip: "Lancer Claude Code avec API tierce (Ignorer la vérification des permissions)",
             api_management: "Gestion des API tierces",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "Mise à niveau terminée !",
         manual_stats_upgraded: "Mis à niveau : {0}",
         manual_stats_skipped: "Ignoré : {0} ({1} déjà à jour, {2} sans info de mise à niveau)"
+    },
+    hints: {
+        auto_mode_info: 'Mode auto : Disponible pour le plan Team. Enterprise/API en cours de deploiement. Apres le lancement, appuyez sur Shift+Tab pour basculer.',
+        active_api_info: 'Actif : {0} / {1}',
+        no_active_api: 'Aucune API active configuree. Allez dans "Gestion des API" pour en ajouter une.'
     }
 };

--- a/lib/i18n/locales/it.js
+++ b/lib/i18n/locales/it.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "Menu Principale",
             launch_default: "Avvia Claude Code",
             launch_skip: "Avvia Claude Code (Salta Automaticamente Permessi)",
+            launch_auto_mode: "Avvia Claude Code (Abilita modalita automatica)",
             launch_api: "Avvia Claude Code con API di Terze Parti",
             launch_api_skip: "Avvia Claude Code con API di Terze Parti (Salta Automaticamente Permessi)",
             api_management: "Gestione API di Terze Parti",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "Aggiornamento completato!",
         manual_stats_upgraded: "Aggiornati: {0}",
         manual_stats_skipped: "Saltati: {0} ({1} già aggiornati, {2} senza info aggiornamento)"
+    },
+    hints: {
+        auto_mode_info: 'Modalita automatica: Attualmente disponibile per il piano Team. Enterprise/API in fase di rilascio graduale. Dopo l\'avvio, premi Shift+Tab per passare.',
+        active_api_info: 'Attivo: {0} / {1}',
+        no_active_api: 'Nessuna API attiva configurata. Vai a "Gestione API" per aggiungerne una.'
     }
 };

--- a/lib/i18n/locales/ja.js
+++ b/lib/i18n/locales/ja.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "メインメニュー",
             launch_default: "Claude Codeを起動",
             launch_skip: "Claude Codeを起動（権限確認をスキップ）",
+            launch_auto_mode: "Claude Code を起動（自動モード有効化）",
             launch_api: "サードパーティAPIでClaude Codeを起動",
             launch_api_skip: "サードパーティAPIでClaude Codeを起動（権限確認をスキップ）",
             api_management: "サードパーティAPI管理",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "アップグレード完了！",
         manual_stats_upgraded: "アップグレード済み：{0}個",
         manual_stats_skipped: "スキップ：{0}個（{1}個は既に最新、{2}個はアップグレード情報なし）"
+    },
+    hints: {
+        auto_mode_info: '自動モード：現在 Team プランで利用可能。Enterprise/API プランは順次展開中。起動後 Shift+Tab で切替。',
+        active_api_info: 'アクティブ：{0} / {1}',
+        no_active_api: 'アクティブなAPIがありません。「API管理」から追加してください。'
     }
 };

--- a/lib/i18n/locales/ko.js
+++ b/lib/i18n/locales/ko.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "메인 메뉴",
             launch_default: "Claude Code 실행",
             launch_skip: "Claude Code 실행 (권한 확인 자동 건너뛰기)",
+            launch_auto_mode: "Claude Code 실행 (자동 모드 활성화)",
             launch_api: "서드파티 API로 Claude Code 실행",
             launch_api_skip: "서드파티 API로 Claude Code 실행 (권한 확인 자동 건너뛰기)",
             api_management: "서드파티 API 관리",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "업그레이드 완료!",
         manual_stats_upgraded: "업그레이드됨: {0}개",
         manual_stats_skipped: "건너뜀: {0}개 ({1}개 이미 최신, {2}개 업그레이드 정보 없음)"
+    },
+    hints: {
+        auto_mode_info: '자동 모드: 현재 Team 플랜에서 지원됩니다. Enterprise/API 플랜은 순차 출시 중입니다. 실행 후 Shift+Tab으로 전환하세요.',
+        active_api_info: '활성: {0} / {1}',
+        no_active_api: '활성화된 API가 없습니다. "API 관리"에서 추가하세요.'
     }
 };

--- a/lib/i18n/locales/pt.js
+++ b/lib/i18n/locales/pt.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "Menu Principal",
             launch_default: "Executar Claude Code",
             launch_skip: "Executar Claude Code (Pular Permissões Automaticamente)",
+            launch_auto_mode: "Iniciar Claude Code (Ativar modo automatico)",
             launch_api: "Executar Claude Code com API de Terceiros",
             launch_api_skip: "Executar Claude Code com API de Terceiros (Pular Permissões Automaticamente)",
             api_management: "Gerenciamento de API de Terceiros",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "Atualização completa!",
         manual_stats_upgraded: "Atualizados: {0}",
         manual_stats_skipped: "Ignorados: {0} ({1} já atualizados, {2} sem info de atualização)"
+    },
+    hints: {
+        auto_mode_info: 'Modo automatico: Disponivel para o plano Team. Enterprise/API em implantacao gradual. Apos iniciar, pressione Shift+Tab para alternar.',
+        active_api_info: 'Ativo: {0} / {1}',
+        no_active_api: 'Nenhuma API ativa configurada. Va para "Gerenciamento de API" para adicionar uma.'
     }
 };

--- a/lib/i18n/locales/ru.js
+++ b/lib/i18n/locales/ru.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "Главное меню",
             launch_default: "Запустить Claude Code",
             launch_skip: "Запустить Claude Code (Автопропуск разрешений)",
+            launch_auto_mode: "Запустить Claude Code (Включить авторежим)",
             launch_api: "Запустить Claude Code со сторонним API",
             launch_api_skip: "Запустить Claude Code со сторонним API (Автопропуск разрешений)",
             api_management: "Управление сторонними API",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "Обновление завершено!",
         manual_stats_upgraded: "Обновлено: {0}",
         manual_stats_skipped: "Пропущено: {0} ({1} уже обновлены, {2} без информации об обновлении)"
+    },
+    hints: {
+        auto_mode_info: 'Авторежим: Доступен для плана Team. Enterprise/API постепенно внедряются. После запуска нажмите Shift+Tab для переключения.',
+        active_api_info: 'Активный: {0} / {1}',
+        no_active_api: 'Нет настроенного активного API. Перейдите в "Управление API", чтобы добавить.'
     }
 };

--- a/lib/i18n/locales/zh-TW.js
+++ b/lib/i18n/locales/zh-TW.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "主選單",
             launch_default: "啟動 Claude Code",
             launch_skip: "啟動 Claude Code（自動跳過權限詢問）",
+            launch_auto_mode: "啟動 Claude Code（啟用自動模式）",
             launch_api: "使用第三方API啟動 Claude Code",
             launch_api_skip: "使用第三方API啟動 Claude Code（自動跳過權限詢問）",
             api_management: "第三方API管理",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "升級完成！",
         manual_stats_upgraded: "已升級：{0} 個",
         manual_stats_skipped: "已跳過：{0} 個（{1} 個已是最新，{2} 個無升級資訊）"
+    },
+    hints: {
+        auto_mode_info: '自動模式：目前支援 Team 方案。Enterprise/API 方案逐步推出中。啟動後按 Shift+Tab 切換。',
+        active_api_info: '目前啟用：{0} / {1}',
+        no_active_api: '未設定啟用的API，請前往「API管理」新增。'
     }
 };

--- a/lib/i18n/locales/zh.js
+++ b/lib/i18n/locales/zh.js
@@ -10,6 +10,7 @@ module.exports = {
             title: "主菜单",
             launch_default: "启动 Claude Code",
             launch_skip: "启动 Claude Code（自动跳过权限询问）",
+            launch_auto_mode: "启动 Claude Code（启用自动模式）",
             launch_api: "使用第三方API启动 Claude Code",
             launch_api_skip: "使用第三方API启动 Claude Code（自动跳过权限询问）",
             api_management: "第三方API管理",
@@ -599,5 +600,10 @@ module.exports = {
         manual_complete: "升级完成!",
         manual_stats_upgraded: "已升级: {0} 个",
         manual_stats_skipped: "已跳过: {0} 个 ({1} 个已是最新, {2} 个无升级信息)"
+    },
+    hints: {
+        auto_mode_info: '自动模式：目前支持 Team 计划。Enterprise/API 计划逐步推出中。启动后按 Shift+Tab 切换。',
+        active_api_info: '当前激活：{0} / {1}',
+        no_active_api: '未配置激活的API，请前往"API管理"添加。'
     }
 };

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -184,6 +184,15 @@ function launchClaudeSkipPermissions() {
 }
 
 /**
+ * Launch Claude with auto mode enabled
+ * Note: --enable-auto-mode makes auto mode available as a permission mode.
+ * User must press Shift+Tab in the session to switch to it.
+ */
+function launchClaudeAutoMode() {
+    launchClaude('claude --enable-auto-mode');
+}
+
+/**
  * Get environment variables based on provider type
  */
 function getProviderEnvVars(api) {
@@ -353,6 +362,7 @@ module.exports = {
     launchClaude,
     launchClaudeDefault,
     launchClaudeSkipPermissions,
+    launchClaudeAutoMode,
     launchClaudeWithApi,
     getProviderEnvVars,
     testApiConnection

--- a/lib/presets/providers.js
+++ b/lib/presets/providers.js
@@ -35,15 +35,18 @@ const providers = {
         compatibility: 'native'
     },
     moonshot: {
-        name: 'Moonshot AI (Kimi-K2)',
+        name: 'Moonshot AI (Kimi-K2.5/K2-Thinking)',
         baseUrl: 'https://api.moonshot.cn/anthropic',
         models: [
-            'kimi-k2-0711-preview',
-            'kimi-k2-0905-preview',
-            'kimi-k2-turbo-preview',
+            'kimi-k2.5',
             'kimi-k2-thinking',
             'kimi-k2-thinking-turbo'
         ],
+        versionAliases: {
+            'kimi-k2-0711-preview': 'kimi-k2.5',
+            'kimi-k2-0905-preview': 'kimi-k2.5',
+            'kimi-k2-turbo-preview': 'kimi-k2.5'
+        },
         authTokenFormat: 'sk-...',
         description: 'Moonshot AI - Provides Anthropic-compatible API',
         requiresToken: true,

--- a/lib/presets/providers.js
+++ b/lib/presets/providers.js
@@ -45,7 +45,9 @@ const providers = {
         versionAliases: {
             'kimi-k2-0711-preview': 'kimi-k2.5',
             'kimi-k2-0905-preview': 'kimi-k2.5',
-            'kimi-k2-turbo-preview': 'kimi-k2.5'
+            'kimi-k2-turbo-preview': 'kimi-k2.5',
+            'kimi-k2-thinking': 'kimi-k2.5',
+            'kimi-k2-thinking-turbo': 'kimi-k2.5'
         },
         authTokenFormat: 'sk-...',
         description: 'Moonshot AI - Provides Anthropic-compatible API',
@@ -77,8 +79,14 @@ const providers = {
         name: 'MiniMax CN (国内版)',
         baseUrl: 'https://api.minimaxi.com/anthropic',
         models: [
+            'MiniMax-M2.7',
+            'MiniMax-M2.5',
             'MiniMax-M2.1'
         ],
+        versionAliases: {
+            'MiniMax-M2.1': 'MiniMax-M2.7',
+            'MiniMax-M2.5': 'MiniMax-M2.7'
+        },
         authTokenFormat: 'sk-...',
         description: 'MiniMax AI - Anthropic-compatible API for China users',
         requiresToken: true,
@@ -93,8 +101,14 @@ const providers = {
         name: 'MiniMax Global (国际版)',
         baseUrl: 'https://api.minimax.io/anthropic',
         models: [
+            'MiniMax-M2.7',
+            'MiniMax-M2.5',
             'MiniMax-M2.1'
         ],
+        versionAliases: {
+            'MiniMax-M2.1': 'MiniMax-M2.7',
+            'MiniMax-M2.5': 'MiniMax-M2.7'
+        },
         authTokenFormat: 'sk-...',
         description: 'MiniMax AI - Anthropic-compatible API for international users',
         requiresToken: true,
@@ -133,7 +147,10 @@ const providers = {
         ],
         versionAliases: {
             'glm-4.5': 'glm-5.1',
-            'glm-4.6': 'glm-5.1'
+            'glm-4.6': 'glm-5.1',
+            'glm-4.7': 'glm-5.1',
+            'glm-5': 'glm-5.1',
+            'glm-5-turbo': 'glm-5.1'
         },
         authTokenFormat: 'sk-...',
         description: 'ZhiPu AI (智谱清言) - Anthropic-compatible API for mainland China',
@@ -156,7 +173,10 @@ const providers = {
         ],
         versionAliases: {
             'glm-4.5': 'glm-5.1',
-            'glm-4.6': 'glm-5.1'
+            'glm-4.6': 'glm-5.1',
+            'glm-4.7': 'glm-5.1',
+            'glm-5': 'glm-5.1',
+            'glm-5-turbo': 'glm-5.1'
         },
         authTokenFormat: 'sk-...',
         description: 'Z.ai (ZhiPu AI Global) - Anthropic-compatible API for international users',

--- a/lib/presets/providers.js
+++ b/lib/presets/providers.js
@@ -120,18 +120,17 @@ const providers = {
         note: 'Requires extended timeout for complex reasoning tasks'
     },
     zhipu: {
-        name: 'ZhiPu AI (GLM-5/4.7/4.6/4.5) - 智谱清言',
+        name: 'ZhiPu AI (GLM-5.1/5-Turbo/5/4.7) - 智谱清言',
         baseUrl: 'https://open.bigmodel.cn/api/anthropic',
         models: [
+            'glm-5.1',
+            'glm-5-turbo',
             'glm-5',
-            'glm-4.7',
-            'glm-4.6',
-            'glm-4.5'
+            'glm-4.7'
         ],
         versionAliases: {
-            'glm-4.5': 'glm-5',
-            'glm-4.6': 'glm-5',
-            'glm-4.7': 'glm-5'
+            'glm-4.5': 'glm-5.1',
+            'glm-4.6': 'glm-5.1'
         },
         authTokenFormat: 'sk-...',
         description: 'ZhiPu AI (智谱清言) - Anthropic-compatible API for mainland China',
@@ -144,18 +143,17 @@ const providers = {
         note: 'Requires extended timeout for large responses'
     },
     zai: {
-        name: 'Z.ai (GLM-5/4.7/4.6/4.5) - ZhiPu Global',
+        name: 'Z.ai (GLM-5.1/5-Turbo/5/4.7) - ZhiPu Global',
         baseUrl: 'https://api.z.ai/api/anthropic',
         models: [
+            'glm-5.1',
+            'glm-5-turbo',
             'glm-5',
-            'glm-4.7',
-            'glm-4.6',
-            'glm-4.5'
+            'glm-4.7'
         ],
         versionAliases: {
-            'glm-4.5': 'glm-5',
-            'glm-4.6': 'glm-5',
-            'glm-4.7': 'glm-5'
+            'glm-4.5': 'glm-5.1',
+            'glm-4.6': 'glm-5.1'
         },
         authTokenFormat: 'sk-...',
         description: 'Z.ai (ZhiPu AI Global) - Anthropic-compatible API for international users',

--- a/lib/ui/menu.js
+++ b/lib/ui/menu.js
@@ -98,7 +98,7 @@ class Menu {
             const hintText = hintCallback(this.selectedIndex);
             if (hintText) {
                 console.log('');
-                console.log(colors.cyan + '  \u2139  ' + colors.yellow + hintText + colors.reset);
+                console.log(colors.green + '  \u2139 ' + hintText + colors.reset);
             }
         }
 

--- a/lib/ui/menu.js
+++ b/lib/ui/menu.js
@@ -60,8 +60,9 @@ class Menu {
      * Display menu with current selection
      * @param {boolean} clearScreen - Whether to clear screen before displaying (default: true)
      * @param {string} versionInfo - Optional version info to display between banner and navigation
+     * @param {Function|null} hintCallback - Optional sync callback(selectedIndex) returning hint string or null
      */
-    displayMenu(clearScreen = true, versionInfo = null) {
+    displayMenu(clearScreen = true, versionInfo = null, hintCallback = null) {
         // Clear screen and display header + menu together (like old version)
         if (clearScreen) {
             console.clear();
@@ -92,6 +93,14 @@ class Menu {
             }
         });
 
+        // Render dynamic hint if callback provided
+        if (hintCallback) {
+            const hintText = hintCallback(this.selectedIndex);
+            if (hintText) {
+                console.log(colors.cyan + '  \u2139 ' + colors.gray + hintText + colors.reset);
+            }
+        }
+
         console.log('');
     }
 
@@ -107,8 +116,9 @@ class Menu {
      * Handle keyboard navigation
      * @param {boolean} clearScreen - Whether to clear screen on initial display (default: true)
      * @param {string} versionInfo - Optional version info to display
+     * @param {Function|null} hintCallback - Optional sync callback(selectedIndex) returning hint string or null
      */
-    async navigate(clearScreen = true, versionInfo = null) {
+    async navigate(clearScreen = true, versionInfo = null, hintCallback = null) {
         // Guard against empty menu to prevent NaN from modulo operations
         if (!this.menuOptions || this.menuOptions.length === 0) {
             console.log(colors.yellow + '  Warning: No menu options available' + colors.reset);
@@ -116,9 +126,10 @@ class Menu {
         }
 
         this.versionInfo = versionInfo; // Store for redrawing
+        this.hintCallback = hintCallback; // Store for redrawing
 
         return new Promise((resolve, reject) => {
-            this.displayMenu(clearScreen, versionInfo);
+            this.displayMenu(clearScreen, versionInfo, hintCallback);
 
             if (process.stdin.isTTY) {
                 const scope = stdinManager.acquire('raw', {
@@ -171,12 +182,12 @@ class Menu {
                         switch (key) {
                             case '\u001b[A': // Up arrow
                                 this.selectedIndex = (this.selectedIndex - 1 + this.menuOptions.length) % this.menuOptions.length;
-                                this.displayMenu(true, this.versionInfo);
+                                this.displayMenu(true, this.versionInfo, this.hintCallback);
                                 break;
 
                             case '\u001b[B': // Down arrow
                                 this.selectedIndex = (this.selectedIndex + 1) % this.menuOptions.length;
-                                this.displayMenu(true, this.versionInfo);
+                                this.displayMenu(true, this.versionInfo, this.hintCallback);
                                 break;
 
                             case '\r': // Enter

--- a/lib/ui/menu.js
+++ b/lib/ui/menu.js
@@ -97,7 +97,8 @@ class Menu {
         if (hintCallback) {
             const hintText = hintCallback(this.selectedIndex);
             if (hintText) {
-                console.log(colors.cyan + '  \u2139 ' + colors.gray + hintText + colors.reset);
+                console.log('');
+                console.log(colors.dim + colors.yellow + '  \u2139 ' + hintText + colors.reset);
             }
         }
 

--- a/lib/ui/menu.js
+++ b/lib/ui/menu.js
@@ -98,7 +98,7 @@ class Menu {
             const hintText = hintCallback(this.selectedIndex);
             if (hintText) {
                 console.log('');
-                console.log(colors.dim + colors.yellow + '  \u2139 ' + hintText + colors.reset);
+                console.log(colors.cyan + '  \u2139  ' + colors.yellow + hintText + colors.reset);
             }
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kikkimo/claude-launcher",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kikkimo/claude-launcher",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kikkimo/claude-launcher",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Interactive launcher for Claude Code with beautiful Claude-style interface",
   "main": "claude-launcher",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node claude-launcher",
-    "test": "echo \"No tests specified\" && exit 0",
+    "test": "node test/providers.test.js && node test/menu-hints.test.js",
     "prepublishOnly": "echo \"Publishing claude-launcher...\"",
     "postinstall": "echo \"Claude Launcher installed successfully! Run 'claude-launcher' to start.\"",
     "publish:public": "npm publish --access public"

--- a/test/menu-hints.test.js
+++ b/test/menu-hints.test.js
@@ -1,0 +1,259 @@
+/**
+ * Tests for Menu hintCallback rendering
+ * Covers both displayMenu() (sync) and navigate() (async, with stubbed stdinManager)
+ */
+
+const assert = require('assert');
+const EventEmitter = require('events');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        passed++;
+        console.log(`  \u2713 ${name}`);
+    } catch (e) {
+        failed++;
+        console.log(`  \u2717 ${name}`);
+        console.log(`    ${e.message}`);
+    }
+}
+
+// Helper: capture console.log output during a function call
+function captureLog(fn) {
+    const logs = [];
+    const original = console.log;
+    const originalClear = console.clear;
+    console.log = (...args) => logs.push(args.join(' '));
+    console.clear = () => {};
+    try {
+        fn();
+    } finally {
+        console.log = original;
+        console.clear = originalClear;
+    }
+    return logs;
+}
+
+const Menu = require('../lib/ui/menu');
+
+// ─── displayMenu with hintCallback ───
+
+test('displayMenu: no hint when hintCallback is null', () => {
+    const m = new Menu();
+    m.setOptions(['Option A', 'Option B']);
+    const logs = captureLog(() => m.displayMenu(false, null, null));
+    const hintLines = logs.filter(l => l.includes('\u2139'));
+    assert.strictEqual(hintLines.length, 0);
+});
+
+test('displayMenu: no hint when hintCallback returns null for selected index', () => {
+    const m = new Menu();
+    m.setOptions(['Option A', 'Option B']);
+    const cb = (idx) => idx === 1 ? 'Some hint' : null;
+    const logs = captureLog(() => m.displayMenu(false, null, cb));
+    const hintLines = logs.filter(l => l.includes('\u2139'));
+    assert.strictEqual(hintLines.length, 0);
+});
+
+test('displayMenu: shows hint when hintCallback returns string for selected index', () => {
+    const m = new Menu();
+    m.setOptions(['Option A', 'Option B']);
+    m.selectedIndex = 1;
+    const cb = (idx) => idx === 1 ? 'Test hint text' : null;
+    const logs = captureLog(() => m.displayMenu(false, null, cb));
+    const hintLines = logs.filter(l => l.includes('\u2139') && l.includes('Test hint text'));
+    assert.strictEqual(hintLines.length, 1);
+});
+
+test('displayMenu: hint changes when selectedIndex changes', () => {
+    const m = new Menu();
+    m.setOptions(['A', 'B', 'C']);
+
+    const cb = (idx) => {
+        if (idx === 0) return 'Hint for A';
+        if (idx === 1) return 'Hint for B';
+        return null;
+    };
+
+    m.selectedIndex = 0;
+    const logs0 = captureLog(() => m.displayMenu(false, null, cb));
+    assert.ok(logs0.some(l => l.includes('Hint for A')));
+
+    m.selectedIndex = 1;
+    const logs1 = captureLog(() => m.displayMenu(false, null, cb));
+    assert.ok(logs1.some(l => l.includes('Hint for B')));
+
+    m.selectedIndex = 2;
+    const logs2 = captureLog(() => m.displayMenu(false, null, cb));
+    assert.ok(!logs2.some(l => l.includes('\u2139')));
+});
+
+test('displayMenu: backward compat - works without hintCallback', () => {
+    const m = new Menu();
+    m.setOptions(['Option A']);
+    const logs = captureLog(() => m.displayMenu(false, null));
+    assert.ok(logs.length > 0);
+    const hintLines = logs.filter(l => l.includes('\u2139'));
+    assert.strictEqual(hintLines.length, 0);
+});
+
+// ─── navigate() pass-through and arrow-key redraw ───
+// These tests call navigate() for real with a stubbed stdinManager,
+// then inject arrow keys and Enter to drive the menu and capture output.
+
+const stdinManager = require('../lib/utils/stdin-manager');
+
+// Helper: create a fake StdinScope
+function createFakeScope() {
+    const emitter = new EventEmitter();
+    emitter.release = () => {};
+    emitter.removeListener = (ev, fn) => emitter.off(ev, fn);
+    return emitter;
+}
+
+// Helper: run an async test
+function asyncTest(name, fn) {
+    return fn().then(() => {
+        passed++;
+        console.log(`  \u2713 ${name}`);
+    }).catch((e) => {
+        failed++;
+        console.log(`  \u2717 ${name}`);
+        console.log(`    ${e.message}`);
+    });
+}
+
+const origIsTTY = process.stdin.isTTY;
+
+const allAsync = Promise.resolve()
+
+.then(() => asyncTest('navigate: accepts hintCallback 3rd param and renders hint on initial draw', async () => {
+    const fakeScope = createFakeScope();
+    const origAcquire = stdinManager.acquire.bind(stdinManager);
+    stdinManager.acquire = () => fakeScope;
+    process.stdin.isTTY = true;
+
+    const m = new Menu();
+    m.setOptions(['A', 'B']);
+    const cb = (idx) => idx === 0 ? 'Initial hint' : null;
+
+    let initialLogs = [];
+    const origLog = console.log;
+    const origClear = console.clear;
+    console.log = (...args) => initialLogs.push(args.join(' '));
+    console.clear = () => {};
+
+    const navPromise = m.navigate(false, null, cb);
+
+    console.log = origLog;
+    console.clear = origClear;
+
+    fakeScope.emit('data', '\r');
+    await navPromise;
+
+    stdinManager.acquire = origAcquire;
+    process.stdin.isTTY = origIsTTY;
+
+    assert.ok(initialLogs.some(l => l.includes('Initial hint')),
+        'Initial displayMenu call should render hint from callback');
+}))
+
+.then(() => asyncTest('navigate: arrow key redraw passes stored hintCallback', async () => {
+    const fakeScope = createFakeScope();
+    const origAcquire = stdinManager.acquire.bind(stdinManager);
+    stdinManager.acquire = () => fakeScope;
+    process.stdin.isTTY = true;
+
+    const m = new Menu();
+    m.setOptions(['A', 'B', 'C']);
+    const cb = (idx) => {
+        if (idx === 1) return 'Hint for B';
+        return null;
+    };
+
+    const origLog = console.log;
+    const origClear = console.clear;
+    console.log = () => {};
+    console.clear = () => {};
+
+    const navPromise = m.navigate(false, null, cb);
+
+    // Inject Down arrow and capture the redraw
+    let downLogs = [];
+    console.log = (...args) => downLogs.push(args.join(' '));
+    fakeScope.emit('data', '\u001b[B'); // Down -> index 1
+
+    console.log = origLog;
+    console.clear = origClear;
+
+    assert.ok(downLogs.some(l => l.includes('Hint for B')),
+        'After arrow down to index 1, hint should show "Hint for B"');
+
+    // Arrow down again to index 2 (no hint)
+    let downLogs2 = [];
+    console.log = (...args) => downLogs2.push(args.join(' '));
+    console.clear = () => {};
+    fakeScope.emit('data', '\u001b[B'); // Down -> index 2
+    console.log = origLog;
+    console.clear = origClear;
+
+    assert.ok(!downLogs2.some(l => l.includes('\u2139')),
+        'After arrow down to index 2, no hint should appear');
+
+    // Resolve
+    console.log = () => {};
+    console.clear = () => {};
+    fakeScope.emit('data', '\r');
+    console.log = origLog;
+    console.clear = origClear;
+    await navPromise;
+
+    stdinManager.acquire = origAcquire;
+    process.stdin.isTTY = origIsTTY;
+}))
+
+.then(() => asyncTest('navigate: without hintCallback (2 args), no hint rendered on arrow', async () => {
+    const fakeScope = createFakeScope();
+    const origAcquire = stdinManager.acquire.bind(stdinManager);
+    stdinManager.acquire = () => fakeScope;
+    process.stdin.isTTY = true;
+
+    const m = new Menu();
+    m.setOptions(['A', 'B']);
+
+    const origLog = console.log;
+    const origClear = console.clear;
+    console.log = () => {};
+    console.clear = () => {};
+
+    const navPromise = m.navigate(false, null);
+
+    let downLogs = [];
+    console.log = (...args) => downLogs.push(args.join(' '));
+    fakeScope.emit('data', '\u001b[B');
+    console.log = origLog;
+    console.clear = origClear;
+
+    assert.ok(!downLogs.some(l => l.includes('\u2139')),
+        'Without hintCallback, no hint should appear on arrow');
+
+    console.log = () => {};
+    console.clear = () => {};
+    fakeScope.emit('data', '\r');
+    console.log = origLog;
+    console.clear = origClear;
+    await navPromise;
+
+    stdinManager.acquire = origAcquire;
+    process.stdin.isTTY = origIsTTY;
+}));
+
+// ─── Summary (after async tests complete) ───
+
+allAsync.then(() => {
+    console.log(`\n  ${passed} passed, ${failed} failed\n`);
+    if (failed > 0) process.exit(1);
+});

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -1,0 +1,182 @@
+/**
+ * Tests for provider model configurations
+ * Verifies model lists, versionAliases, and upgrade detection
+ */
+
+const assert = require('assert');
+const {
+    getProvider,
+    getLatestModel,
+    hasModelUpgrade,
+    getSuggestedModels,
+    providers
+} = require('../lib/presets/providers');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+    try {
+        fn();
+        passed++;
+        console.log(`  \u2713 ${name}`);
+    } catch (e) {
+        failed++;
+        console.log(`  \u2717 ${name}`);
+        console.log(`    ${e.message}`);
+    }
+}
+
+// ─── GLM (zhipu) ───
+
+test('zhipu: models list is correct', () => {
+    const p = getProvider('zhipu');
+    assert.deepStrictEqual(p.models, ['glm-5.1', 'glm-5-turbo', 'glm-5', 'glm-4.7']);
+});
+
+test('zhipu: name includes all current model families', () => {
+    const p = getProvider('zhipu');
+    assert.ok(p.name.includes('GLM-5.1'));
+    assert.ok(p.name.includes('5-Turbo'));
+});
+
+test('zhipu: removed glm-4.5 aliases to glm-5.1', () => {
+    assert.strictEqual(getLatestModel('glm-4.5', 'zhipu'), 'glm-5.1');
+});
+
+test('zhipu: removed glm-4.6 aliases to glm-5.1', () => {
+    assert.strictEqual(getLatestModel('glm-4.6', 'zhipu'), 'glm-5.1');
+});
+
+test('zhipu: glm-4.7 aliases to glm-5.1', () => {
+    assert.strictEqual(getLatestModel('glm-4.7', 'zhipu'), 'glm-5.1');
+});
+
+test('zhipu: glm-5 aliases to glm-5.1', () => {
+    assert.strictEqual(getLatestModel('glm-5', 'zhipu'), 'glm-5.1');
+});
+
+test('zhipu: glm-5-turbo aliases to glm-5.1', () => {
+    assert.strictEqual(getLatestModel('glm-5-turbo', 'zhipu'), 'glm-5.1');
+});
+
+test('zhipu: latest glm-5.1 has no alias', () => {
+    assert.strictEqual(getLatestModel('glm-5.1', 'zhipu'), null);
+});
+
+// ─── GLM (zai) — must mirror zhipu ───
+
+test('zai: models list matches zhipu', () => {
+    const z = getProvider('zhipu');
+    const a = getProvider('zai');
+    assert.deepStrictEqual(a.models, z.models);
+});
+
+test('zai: versionAliases matches zhipu', () => {
+    const z = getProvider('zhipu');
+    const a = getProvider('zai');
+    assert.deepStrictEqual(a.versionAliases, z.versionAliases);
+});
+
+// ─── Kimi (moonshot) ───
+
+test('moonshot: models list is correct', () => {
+    const p = getProvider('moonshot');
+    assert.deepStrictEqual(p.models, ['kimi-k2.5', 'kimi-k2-thinking', 'kimi-k2-thinking-turbo']);
+});
+
+test('moonshot: removed kimi-k2-0711-preview aliases to kimi-k2.5', () => {
+    assert.strictEqual(getLatestModel('kimi-k2-0711-preview', 'moonshot'), 'kimi-k2.5');
+});
+
+test('moonshot: removed kimi-k2-0905-preview aliases to kimi-k2.5', () => {
+    assert.strictEqual(getLatestModel('kimi-k2-0905-preview', 'moonshot'), 'kimi-k2.5');
+});
+
+test('moonshot: removed kimi-k2-turbo-preview aliases to kimi-k2.5', () => {
+    assert.strictEqual(getLatestModel('kimi-k2-turbo-preview', 'moonshot'), 'kimi-k2.5');
+});
+
+test('moonshot: kimi-k2-thinking aliases to kimi-k2.5', () => {
+    assert.strictEqual(getLatestModel('kimi-k2-thinking', 'moonshot'), 'kimi-k2.5');
+});
+
+test('moonshot: kimi-k2-thinking-turbo aliases to kimi-k2.5', () => {
+    assert.strictEqual(getLatestModel('kimi-k2-thinking-turbo', 'moonshot'), 'kimi-k2.5');
+});
+
+test('moonshot: latest kimi-k2.5 has no alias', () => {
+    assert.strictEqual(getLatestModel('kimi-k2.5', 'moonshot'), null);
+});
+
+// ─── MiniMax ───
+
+test('minimax_cn: models list is correct', () => {
+    const p = getProvider('minimax_cn');
+    assert.deepStrictEqual(p.models, ['MiniMax-M2.7', 'MiniMax-M2.5', 'MiniMax-M2.1']);
+});
+
+test('minimax_cn: MiniMax-M2.1 aliases to MiniMax-M2.7', () => {
+    assert.strictEqual(getLatestModel('MiniMax-M2.1', 'minimax_cn'), 'MiniMax-M2.7');
+});
+
+test('minimax_cn: MiniMax-M2.5 aliases to MiniMax-M2.7', () => {
+    assert.strictEqual(getLatestModel('MiniMax-M2.5', 'minimax_cn'), 'MiniMax-M2.7');
+});
+
+test('minimax_cn: latest MiniMax-M2.7 has no alias', () => {
+    assert.strictEqual(getLatestModel('MiniMax-M2.7', 'minimax_cn'), null);
+});
+
+test('minimax_global: models list matches minimax_cn', () => {
+    const cn = getProvider('minimax_cn');
+    const gl = getProvider('minimax_global');
+    assert.deepStrictEqual(gl.models, cn.models);
+});
+
+test('minimax_global: versionAliases matches minimax_cn', () => {
+    const cn = getProvider('minimax_cn');
+    const gl = getProvider('minimax_global');
+    assert.deepStrictEqual(gl.versionAliases, cn.versionAliases);
+});
+
+// ─── Unchanged providers — regression guard ───
+
+test('anthropic: models unchanged, includes claude-opus-4-6', () => {
+    const p = getProvider('anthropic');
+    assert.ok(p.models.includes('claude-opus-4-6'));
+    assert.ok(p.models.includes('claude-sonnet-4-5'));
+});
+
+test('anthropic: versionAliases still map opus series', () => {
+    assert.strictEqual(getLatestModel('claude-opus-4', 'anthropic'), 'claude-opus-4-6');
+});
+
+test('deepseek: models unchanged', () => {
+    const p = getProvider('deepseek');
+    assert.deepStrictEqual(p.models, ['deepseek-chat', 'deepseek-reasoner']);
+});
+
+test('kimi_for_coding: models unchanged', () => {
+    const p = getProvider('kimi_for_coding');
+    assert.deepStrictEqual(p.models, ['kimi-for-coding']);
+});
+
+// ─── Cross-cutting: latest model in each provider has no alias ───
+
+test('invariant: the first model in each provider has no versionAlias (is the latest)', () => {
+    for (const [id, provider] of Object.entries(providers)) {
+        if (!provider.versionAliases || !provider.models || provider.models.length === 0) continue;
+        const latest = provider.models[0];
+        assert.strictEqual(
+            provider.versionAliases[latest] || null,
+            null,
+            `Provider "${id}": first model "${latest}" should not be in versionAliases`
+        );
+    }
+});
+
+// ─── Summary ───
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Summary
- **GLM models**: Add `glm-5.1` and `glm-5-turbo`, remove deprecated `glm-4.5`/`glm-4.6` for zhipu and zai providers
- **Kimi models**: Add `kimi-k2.5`, remove 3 deprecated preview versions for moonshot provider
- **MiniMax models**: Add `MiniMax-M2.7` and `MiniMax-M2.5` for minimax_cn and minimax_global providers
- **Auto Mode**: New menu item "Launch Claude Code (Enable Auto Mode)" using `claude --enable-auto-mode`
- **Dynamic menu hints**: Context-sensitive hints below the main menu (auto mode plan info, active API info)
- **Test suite**: 36 automated tests (28 provider + 8 menu hint) wired to `npm test`
- **i18n**: All 11 locale files updated with 4 new translation keys
- **Version**: Bumped to 2.5.0

## Test plan
- [x] `npm test` passes all 36 tests (providers + menu hints)
- [x] `node --check claude-launcher` syntax check passes
- [x] All 11 locales verified with 4-key deep check
- [ ] Manual smoke test: launch app, verify 9 menu items, dynamic hints, arrow navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **新功能**
  * 新增"启用自动模式"菜单选项（Shift+Tab 切换）
  * 菜单下方新增动态上下文感知提示

* **更新**
  * 支持新 AI 模型版本：GLM-5.1、Kimi K2.5、MiniMax M2.7 等
  * 更新所有 11 种语言的用户界面文本

* **测试**
  * 新增自动化测试套件

* **发版**
  * 版本更新至 2.5.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->